### PR TITLE
Fix a YAML padding

### DIFF
--- a/templates/jobs/spec
+++ b/templates/jobs/spec
@@ -74,7 +74,7 @@ properties:
     description: 'URL to access service'
   {{ package.name }}.user:
      description: 'Basic auth username to access service'
- {{ package.name }}.password:
+  {{ package.name }}.password:
      description: 'Basic auth password to access service'
 {% elif package.is_broker %}
   {{ package.name }}.user:


### PR DESCRIPTION
Otherwise the parser used by BOSH 1.3202.0 fails to parse the file complaining:

```
Building common...
  No artifact found for common
  Generating...
  Pre-packaging...
Job spec is missing or invalid: Incorrect YAML structure in `...': (<unknown>): did not find expected key while parsing a block mapping at line 2 column 1
```
