### PR TITLE
add basic support for markdown in forms

### DIFF
--- a/templates/tile/metadata.yml
+++ b/templates/tile/metadata.yml
@@ -149,6 +149,10 @@ form_types:
 - name: {{ form.name }}
   label: {{ form.label }}
   description: {{ form.description or form.label }}
+  {% if form.markdown %}
+  markdown: |
+    {{ form.markdown | indent(4, False) }}
+  {% endif %}
   property_inputs:
   {% for property in form.properties %}
   - reference: .properties.{{ property.name }}

--- a/templates/tile/metadata.yml
+++ b/templates/tile/metadata.yml
@@ -151,7 +151,7 @@ form_types:
   description: {{ form.description or form.label }}
   {% if form.markdown %}
   markdown: |
-    {{ form.markdown | indent(4, False) }}
+    {{ form.markdown | indent }}
   {% endif %}
   property_inputs:
   {% for property in form.properties %}


### PR DESCRIPTION
for example, the following `tile.yml`.

```
forms:
- name: my-markdown-form
  label: Markdown Form
  description: This is an example form using markdown
  markdown: |
    ![Here is a cat](https://i.ytimg.com/vi/Lf0kGBW01Vg/hqdefault.jpg)
    # Header
    **bold**
    etc
  properties:
  - name: my-prop
    type: string
    label: My Prop
    description: This is a demo property.
```
