### PR TITLE
property handling updates - constraints and configurable

### DIFF
--- a/lib/build.py
+++ b/lib/build.py
@@ -86,7 +86,8 @@ def add_defaults(context):
 	for form in context.get('forms', []):
 		properties = form.get('properties', [])
 		for property in properties:
-			property['configurable'] = 'true'
+			if 'configurable' not in property:
+				property['configurable'] = 'true'
 		context['all_properties'] += properties
 	for property in context['all_properties']:
 		property['name'] = property['name'].lower().replace('-','_')

--- a/templates/tile/metadata.yml
+++ b/templates/tile/metadata.yml
@@ -126,6 +126,10 @@ property_blueprints:
   default: {{ property.default }}
   {% endif %}
   configurable: {{ property.configurable or 'false' }}
+  {% if property.constraints is defined %}
+  constraints:
+    {{ property.constraints | yaml | indent }}
+  {% endif %}
   {% if property.options is defined %}
   options:
   {% for option in property.options %}


### PR DESCRIPTION
Two further small updates to property handling, thanks.

Allows constraints to be passed in a property, for example:

```
  properties:
  - name: confirm_install
    type: string
    label: Type yes to confirm installation.
    description: You must confirm the installation by typing yes.
    constraints:
      - must_match_regex: '^[Yy][Ee][Ss]$'
        error_message: '. Invalid response.'
```

Also updates `build.py` to stop explicity set `configurable: false` in properties from being blown away (was being overridden by the default `true` that was being set). For example:

```
  properties:
  - name: non_configurable_property
    type: text
    configurable: false
    label: Non Configurable Property
    description: This property should not be configurable when rendered in Ops Manager.
```
