### PR TITLE
add optional to property_blueprint

### DIFF
--- a/templates/tile/metadata.yml
+++ b/templates/tile/metadata.yml
@@ -126,6 +126,7 @@ property_blueprints:
   default: {{ property.default }}
   {% endif %}
   configurable: {{ property.configurable or 'false' }}
+  optional: {{ property.optional or 'false' }}
   {% if property.constraints is defined %}
   constraints:
     {{ property.constraints | yaml | indent }}


### PR DESCRIPTION
allows form fields to be set as optional.
