### PR TITLE
Using the package name instead of parsing name from the filename.

### DIFF
--- a/lib/build.py
+++ b/lib/build.py
@@ -403,7 +403,7 @@ def add_bosh_release(context, package):
 	try:
 		release_file = os.path.basename(package['path']) # my_bosh_release-6.tgz
 		basename = release_file.rsplit('.', 1)[0] # my_bosh_release-6
-		release_name = basename.rsplit('-', 1)[0] # my_bosh_release
+		release_name = package['name']
 		release_version = basename.rsplit('-', 1)[1] # 6
 	except Exception as e:
 		print >> sys.stderr, "bosh-release must have a path attribute of the form <name>_<version>.tgz"


### PR DESCRIPTION
I had an issue where the tile's manifest that is created had a package name that did not match the name of the bosh release being used.  Such was the case with docker-boshrelease whose filename was docker-boshrelease-27.tgz

In tile.yml, I have:
- name: docker
  type: bosh-release
  path: resources/docker-boshrelease-27.tgz

I thus specify that the name of the bosh release stored in docker-boshrelease-27.tgz is 'docker'

The tile generator parsed the filename, and extracted docker-boshrelease and used that to populate the releases: section of the tile's manifest, producing:
- file: docker-boshrelease-27.tgz
  name: docker-boshrelease
  version: '27'

instead of:
- file: docker-boshrelease-27.tgz
  name: docker
  version: '27'
