### PR TITLE
Add flag to skip pcf configure's validation

### DIFF
--- a/tile_generator/opsmgr.py
+++ b/tile_generator/opsmgr.py
@@ -231,7 +231,7 @@ def get_job_guid(job_identifier, jobs_settings):
 	print('Could not find job with identifier', job_identifier, file=sys.stderr)
 	sys.exit(1)
 
-def configure(product, properties, strict=False):
+def configure(product, properties, strict=False, skip_validation=False):
 	settings = get('/api/installation_settings').json()
 	infrastructure = settings['infrastructure']
 	product_settings = [ p for p in settings['products'] if p['identifier'] == product ]
@@ -286,7 +286,7 @@ def configure(product, properties, strict=False):
 		else:
 			if p.get('value', None) is None:
 				missing_properties += [ key ]
-	if len(missing_properties) > 0:
+	if not skip_validation and len(missing_properties) > 0:
 		print('Input file is missing required properties:', file=sys.stderr)
 		print('- ' + '\n- '.join(missing_properties), file=sys.stderr)
 		sys.exit(1)

--- a/tile_generator/pcf.py
+++ b/tile_generator/pcf.py
@@ -80,12 +80,13 @@ def is_installed_cmd(product, version):
 @click.argument('product')
 @click.argument('properties_file', None, required=False)
 @click.option('--strict', is_flag=True)
-def configure_cmd(product, properties_file, strict=False):
+@click.option('--skip-validation', is_flag=True)
+def configure_cmd(product, properties_file, strict=False, skip_validation=False):
 	properties = {}
 	if properties_file is not None:
 		with open(properties_file) as f:
 			properties = yaml.safe_load(f)
-	opsmgr.configure(product, properties, strict)
+	opsmgr.configure(product, properties, strict, skip_validation)
 
 @cli.command('settings')
 @click.argument('product', None, required=False)


### PR DESCRIPTION
In 1.8, configure's validation is overzealous. I have a tile with several properties where optional is true and they contain now value, but configure still tells me that they're required.
