### PR TITLE
Adding placeholder fields in selector inputs properties.

### DIFF
--- a/tile_generator/templates/tile/metadata.yml
+++ b/tile_generator/templates/tile/metadata.yml
@@ -147,6 +147,9 @@ form_types:
       - reference: .properties.{{ property.name }}.{{ option.name }}.{{ input.name }}
         label: {{ input.label }}
         description: {{ input.description or input.label }}
+        {% if input.placeholder %}
+        placeholder: {{ input.placeholder }}
+        {% endif %}
       {% endfor %}
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
Currently, tile-generator is unable to generate selector inputs which contains field with placeholders.  This PR adds placeholder fields to the selector inputs when a placeholder is specified.

Sample tile.yml snippet with placeholder in the selector inputs that was used to test this PR : 
```
- name: auth_config
   label: Authentication and Authorization
   description: Configure external user store (LDAP)
   properties:
   - name: auth_selector
     type: selector
     label: Configure the VMR authentication and authorization with either internal or LDAP authentication/authorization mechanism
     configurable: true
     default: VMR Internal
     option_templates:
     - name: vmr_internal
       select_value: VMR Internal
     - name: ldap_server
       select_value: LDAP Server
       property_blueprints:
       - name: ldap_url
         label: LDAP Server URL
         type: ldap_url
         placeholder: "'ldaps://ldap.domain.com'"
         description: "'Required for LDAP. Must start with `ldap://` or `ldaps://`.  Multiple entries can be separated by spaces.  A maximum of 10 entries is supported.'"
         configurable: true
       - name: ldap_credentials
         label: LDAP Credentials
         type: simple_credentials
         configurable: true
       - name: user_search_base
         label: User Search Base
         type: string
         placeholder: "'cn=users,dc=example,dc=com'"
         description: "'Required for LDAP. Example: `ou=Users,dc=example,dc=com.`'"
         configurable: true
```