### PR TITLE
Making the description field of selector inputs optional.

### DIFF
--- a/tile_generator/templates/tile/metadata.yml
+++ b/tile_generator/templates/tile/metadata.yml
@@ -146,7 +146,9 @@ form_types:
       {% for input in option.property_blueprints %}
       - reference: .properties.{{ property.name }}.{{ option.name }}.{{ input.name }}
         label: {{ input.label }}
-        description: {{ input.description or input.label }}
+        {% if input.description %}
+        description: {{ input.description }}
+        {% endif %}
       {% endfor %}
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
If one needs to have a form defined as :
```
   - name: auth_selector
     type: selector
     label: Configure the VMR authentication and authorization with either internal or LDAP authentication/authorization mechanism
     configurable: true
     default: VMR Internal
     option_templates:
     - name: vmr_internal
       select_value: VMR Internal
     - name: ldap_server
       select_value: LDAP Server
       property_blueprints:
       - name: ldap_url
         label: LDAP Server URL
         type: ldap_url
         placeholder: "'ldaps://ldap.domain.com'"
         description: "'Required for LDAP. Must start with `ldap://` or `ldaps://`.  Multiple entries can be separated by spaces.  A maximum of 10 entries is supported.'"
         configurable: true

.......

       - name: user_group_attribute
         label: User Group Membership Attribute Name
         type: string
         default: memberOf
         description: "'Attribute of the user LDAP entry which contains the user group.'"
         configurable: true
       - name: ldap_referrals
         type: dropdown_select
         label: LDAP Referrals
         options:
         - label: Automatically follow any referrals
           name: follow
           default: true
         - label: Ignore referrals and return partial result
           name: ignore
         - label: Throw exception for each referral and abort authentication
           name: throw
```

The Tile generator adds a description for ldap_referrals using the label.  This prevents the user from having fields with no description.  This PR makes the description field optional so the user have an option of not having descriptions when not desired.

Alternatively, to preserve backward compatibility, we could instead have a new field which would signal the intention of not having a description.  Please advice on this.  IE : 
```
       - name: ldap_referrals
         type: dropdown_select
         label: LDAP Referrals
         omitDescription: true
```