### PR TITLE
Allow properties to be de-referenced

### DIFF
--- a/tile_generator/template.py
+++ b/tile_generator/template.py
@@ -147,8 +147,10 @@ def render_property(property):
 				fields[field] = '(( .properties.{}.{} ))'.format(property['name'], field)
 		out = { property['name']: fields }
 	else:
-		# Other types use 'value'.
-		out = { property['name']: '(( .properties.{}.value ))'.format(property['name']) }
+		if property.get('is_reference', False):
+			out = { property['name']: property['default'] }
+		else:
+			out = { property['name']: '(( .properties.{}.value ))'.format(property['name']) }
 	return out
 
 @contextfilter


### PR DESCRIPTION
If you have a properties block like:

```
properties:
- name: admin_client_id
  type: string
  value: (( ..cf.uaa.admin_client_credentials.value ))
```

When it's included in a manifest for an `app` job, it looks like this:

```
...
manifest: |
  admin_client_id: (( .properties.admin_client_id.value ))
...
```

Which will end up setting an environment variable on the app `ADMIN_CLIENT_ID` with value `(( ..cf.uaa.admin_client_credentials.value ))`. This prevents us from sending platform info to the app as an environment variable (another example we saw was sending in the system domain).

This pull request adds a field to a property called `is_reference` (default `False`) that, if `True`, will
take the actual value into the manifest. Therefore, the block above with the new field:

```
properties:
- name: admin_client_id
  type: string
  value: (( ..cf.uaa.admin_client_credentials.value ))
  is_reference: true
```

will result in the following manifest block:

```
...
manifest: |
  admin_client_id: (( ..cf.uaa.admin_client_credentials.value ))
...
```

Which in turn creates an env variable `ADMIN_CLIENT_ID=admin` in the app.