### PR TITLE
catch missing package file with a friendly error instead of a stack trace

### DIFF
--- a/tile_generator/config.py
+++ b/tile_generator/config.py
@@ -109,7 +109,7 @@ class Config(dict):
 					'package': package
 				}]
 			if package.get('is_decorator', False):
-				release['requires_meta_buildpack'] = True				
+				release['requires_meta_buildpack'] = True
 			if 'is_app' in flags:
 				manifest = package.get('manifest', { 'name': package['name'] })
 				if not 'is_docker' in flags:
@@ -441,6 +441,9 @@ class Config(dict):
 
 	def update_compilation_vm_disk_size(self, manifest):
 		package_file = manifest.get('path')
+		if not os.path.exists(package_file):
+			print('Package file "{}" not found! Please check the manifest path in your tile.yml file.'.format(package_file), file=sys.stderr)
+			sys.exit(1)
 		package_size = os.path.getsize(package_file) // (1024 * 1024) # bytes to megabytes
 		self['compilation_vm_disk_size'] = max(self['compilation_vm_disk_size'], 4 * package_size)
 


### PR DESCRIPTION
(plus a random whitespace change - removing trailing whitespace from a line)

After this change:
```➜  tile build 
Package file "gosrc/cloudfoundry-honeycomb-nozzle" not found! Please check the Manifest path in your tile.yml file.
```

Before the change:
```
➜  tile build
Traceback (most recent call last):
  File "/usr/local/bin/tile", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/tile_generator/tile.py", line 52, in build_cmd
    cfg = Config().read()
  File "/usr/local/lib/python2.7/site-packages/tile_generator/config.py", line 80, in read
    self.transform()
  File "/usr/local/lib/python2.7/site-packages/tile_generator/config.py", line 87, in transform
    self.process_packages()
  File "/usr/local/lib/python2.7/site-packages/tile_generator/config.py", line 116, in process_packages
    self.update_compilation_vm_disk_size(manifest)
  File "/usr/local/lib/python2.7/site-packages/tile_generator/config.py", line 440, in update_compilation_vm_disk_size
    package_size = os.path.getsize(package_file) // (1024 * 1024) # bytes to megabytes
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/genericpath.py", line 57, in getsize
    return os.stat(filename).st_size
OSError: [Errno 2] No such file or directory: 'gosrc/cloudfoundry-honeycomb-nozzle'
```