### PR TITLE
check for existence of same broker only

### DIFF
--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -258,7 +258,7 @@ function register_broker() {
 	BROKER_URL="$4"
 	GLOBAL_ACCESS="$5"
 	BROKER_SERVICES="$6"
-	$CF service-brokers | grep $BROKER_NAME >/dev/null
+	$CF service-brokers | grep "^$BROKER_NAME " >/dev/null
 	if [ "$?" -ne "0" ]; then
 		cf create-service-broker "$BROKER_NAME" "$BROKER_USER" "$BROKER_PASS" "$BROKER_URL"
 	else


### PR DESCRIPTION
If the URL of an existing broker-app also contains the name of a new broker (BROKER_NAME) the deployment of the service-broker tile fails. It also fails if there are other brokers that start with the same name.

Example:
BROKER_NAME of new broker: 'foo'
Existing brokers: 'foobar', 'foo2'

This PR fixes the check for existing brokers.