### PR TITLE
Clean up SSH code and automate bosh login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
 		'requests>=2.9.1,<2.11',
 		'requests-toolbelt',
 		'mock>=2.0.0',
+		'pexpect>=4.2.1'
 	],
 	include_package_data = True,
 	entry_points = {

--- a/tile_generator/pcf.py
+++ b/tile_generator/pcf.py
@@ -38,22 +38,13 @@ def cli(target, non_interactive):
 
 @cli.command('ssh')
 @click.argument('argv', nargs=-1)
-@click.option('--debug', '-d', is_flag=True)
-def ssh_cmd(argv, debug=False):
-	opsmgr.ssh(argv, debug=debug)
+@click.option('--skip-bosh-login', '-s', is_flag=True)
+def ssh_cmd(argv, skip_bosh_login=False):
+	opsmgr.ssh(command=' '.join(argv), login_to_bosh=not(skip_bosh_login))
 
 @cli.command('reboot')
-@click.option('--yes-i-am-sure', '-y', is_flag=True)
-def reboot_cmd(yes_i_am_sure=False):
-	if not yes_i_am_sure:
-		print('Rebooting in', end="")
-		for i in range(10, 0, -1):
-			sys.stdout.write(' ' +str(i))
-			sys.stdout.flush()
-			time.sleep(1)
-		print()
-	opsmgr.ssh(['sudo reboot now'], silent=True)
-	time.sleep(10) # Allow system time to go down before we ping the API
+def reboot_cmd():
+	opsmgr.ssh(command='sudo reboot now', login_to_bosh=False)
 	opsmgr.unlock()
 
 @cli.command('unlock')

--- a/tile_generator/pcf.py
+++ b/tile_generator/pcf.py
@@ -418,14 +418,10 @@ def credentials_cmd():
 def bosh_env_cmd():
 	director_creds = opsmgr.get('/api/v0/deployed/director/credentials/director_credentials').json()
 	director_manifest = opsmgr.get('/api/v0/deployed/director/manifest').json()
-	print('1. Run `pcf -t <target> ssh` to log in to the Ops Manager VM.')
-	print('2. Set these variables:')
-	print('export BOSH_ENVIRONMENT="{}"'.format(director_manifest['jobs'][0]['properties']['director']['address']))
-	print('export BOSH_CA_CERT="/var/tempest/workspaces/default/root_ca_certificate"')
-	print('to target the BOSH environment.')
-	print('3. Run `bosh2 login` with the following username and password:')
-	print('username: {}'.format(director_creds['credential']['value']['identity']))
-	print('password: {}'.format(director_creds['credential']['value']['password']))
+	print('BOSH_ENVIRONMENT="{}"'.format(director_manifest['jobs'][0]['properties']['director']['address']))
+	print('BOSH_CA_CERT="/var/tempest/workspaces/default/root_ca_certificate"')
+	print('BOSH USERNAME={}'.format(director_creds['credential']['value']['identity']))
+	print('BOSH PASSWORD={}'.format(director_creds['credential']['value']['password']))
 
 @cli.command('history')
 def history_cmd():


### PR DESCRIPTION
* Replaced paramiko(esque) interactive ssh code with pexpect's pxssh.
* Changed bosh-env to only show the env and not display instructions.
* Automate exporting the bosh env vars
* Non-interactively interactively login to bosh2 (until uaac for bosh are used)
* Handle commands sent as arguments to the ssh command
* Detect when `sudo` is passed as a command and attempt to login automagically 