### PR TITLE
Fix 219

### DIFF
--- a/tile_generator/config_unittest.py
+++ b/tile_generator/config_unittest.py
@@ -168,9 +168,6 @@ class TestUltimateForm(BaseTest):
 		expected = json.dumps(expected_output, sort_keys=True, indent=1).split('\n')
 		remove_ignored_keys(d_cfg)
 		generated = json.dumps(d_cfg, sort_keys=True, indent=1).split('\n')
-                # Use this on the odd chance you want to capture and see the generated output in a file.
-		# with open(test_path + '/test_config_generated_output', 'w') as f:
-		# 	f.write(str(d_cfg))
 		self.assertEquals(len(expected), len(generated))
 		for line in expected:
 			self.assertIn(line, generated)

--- a/tile_generator/config_unittest.py
+++ b/tile_generator/config_unittest.py
@@ -151,7 +151,6 @@ class TestUltimateForm(BaseTest):
 				self.assertEquals(expected, given, (path, 'Expected to have the value:\n%s\nHowever, instead got:\n%s' % (expected, given)))
 
 
-                # Confirm that the new consumes: contains 'redis'
 		for release in cfg['releases']:
                     if release.has_key('consumes_for_deployment'):
                         self.assertDictEqual({'from': 'redis'}, release['consumes_for_deployment']['redis'])

--- a/tile_generator/config_unittest.py
+++ b/tile_generator/config_unittest.py
@@ -154,7 +154,7 @@ class TestUltimateForm(BaseTest):
                 # Confirm that the new consumes: contains 'redis'
 		for release in cfg['releases']:
                     if release.has_key('consumes_for_deployment'):
-                        self.assertIn("'from': 'redis'", str(release['consumes_for_deployment']['redis']))
+                        self.assertDictEqual({'from': 'redis'}, release['consumes_for_deployment']['redis'])
                         # Remove it so it is compatible with the OLD expected output
                         release['consumes_for_deployment'].pop('redis')
 

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -197,9 +197,9 @@ class App(FlagBase):
         for link_name, link in package.get('consumes', {}).iteritems():
             release['consumes'] = release.get('consumes', {})
             release['consumes'][link_name] = link
-            if 'deployment' in link:
-                release['consumes_cross_deployment'] = release.get('consumes_cross_deployment', {})
-                release['consumes_cross_deployment'][link_name] = link
+            release['consumes_for_deployment'] = release.get('consumes_for_deployment', {})
+            release['consumes_for_deployment'][link_name] = link.copy()
+            release['consumes_for_deployment'][link_name].pop('type',None)
         manifest = package.get('manifest', { 'name': package['name'] })
         package['app_manifest'] = manifest
         if manifest.get('path'):

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -201,8 +201,6 @@ class App(FlagBase):
             release['consumes_for_deployment'][link_name] = link.copy()
             release['consumes_for_deployment'][link_name].pop('type',None)
             release['consumes_for_deployment'][link_name].pop('optional',None)
-            if 'optional' not in link:
-               link['optional'] = False
         manifest = package.get('manifest', { 'name': package['name'] })
         package['app_manifest'] = manifest
         if manifest.get('path'):

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -200,6 +200,9 @@ class App(FlagBase):
             release['consumes_for_deployment'] = release.get('consumes_for_deployment', {})
             release['consumes_for_deployment'][link_name] = link.copy()
             release['consumes_for_deployment'][link_name].pop('type',None)
+            release['consumes_for_deployment'][link_name].pop('optional',None)
+            if 'optional' not in link:
+               link['optional'] = False
         manifest = package.get('manifest', { 'name': package['name'] })
         package['app_manifest'] = manifest
         if manifest.get('path'):

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -194,12 +194,12 @@ class App(FlagBase):
         # TODO: Remove the dependency on this in templates
         package['is_app'] = True
 
-        for link_type, link in package.get('consumes', {}).iteritems():
+        for link_name, link in package.get('consumes', {}).iteritems():
             release['consumes'] = release.get('consumes', {})
-            release['consumes'][link_type] = link
+            release['consumes'][link_name] = link
             if 'deployment' in link:
                 release['consumes_cross_deployment'] = release.get('consumes_cross_deployment', {})
-                release['consumes_cross_deployment'][link_type] = link
+                release['consumes_cross_deployment'][link_name] = link
         manifest = package.get('manifest', { 'name': package['name'] })
         package['app_manifest'] = manifest
         if manifest.get('path'):

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -61,11 +61,10 @@ function import_opsmgr_variables() {
 	<% hosts = link.instances.map { |instance| instance.address } %>
 	export {{ link | upper }}_HOST="<%= link.instances[0].address %>"
 	export {{ link | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
-    export {{ link | upper }}_PROPERTIES=<%= Shellwords.escape(link.properties.to_json) %>
+        export {{ link | upper }}_PROPERTIES=<%= Shellwords.escape(link.properties.to_json) %>
 	<% end %>
-
 	{% endfor %}
-    {% endfor %}
+	{% endfor %}
 
 }
 

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -59,7 +59,7 @@ function import_opsmgr_variables() {
 	{% for link in release.consumes %}
 	<% if_link('{{ link }}') do |link| %>
 	<% hosts = link.instances.map { |instance| instance.address } %>
-	export {{ link | upper }}_HOST="<%= link.instances[0].address %>"
+	export {{ link | upper }}_HOST="<%= link.instances.empty? ? ( puts "" ) : ( puts link.instances[0].address ) %>"
 	export {{ link | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
         export {{ link | upper }}_PROPERTIES=<%= Shellwords.escape(link.properties.to_json) %>
 	<% end %>

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -55,6 +55,8 @@ function import_opsmgr_variables() {
 	{% endif %}
 	{% endfor %}
 	{% endfor %}
+	<% empty_dict = {} %>
+	<% empty_list = [] %>
 	{% for release in context.releases.values() if release.consumes %}
 	{% for link in release.consumes %}
 	<% if_link('{{ link }}') do |link| %>
@@ -62,6 +64,10 @@ function import_opsmgr_variables() {
 	export {{ link | upper }}_HOST="<%= link.instances.empty? ? ( puts "" ) : ( puts link.instances[0].address ) %>"
 	export {{ link | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
         export {{ link | upper }}_PROPERTIES=<%= Shellwords.escape(link.properties.to_json) %>
+        <% end.else do %>
+	export {{ link | upper }}_HOST=<%= Shellwords.escape(empty_list.to_json) %>
+	export {{ link | upper }}_HOSTS=<%= Shellwords.escape(empty_list.to_json) %>
+        export {{ link | upper }}_PROPERTIES=<%= Shellwords.escape(empty_dict.to_json) %>
 	<% end %>
 	{% endfor %}
 	{% endfor %}
@@ -173,13 +179,12 @@ function add_env_vars() {
 	{% endfor %}
 	{% endfor %}
 
+	# Addresses and Properties Provided by bosh links
 	{% for release in context.releases.values() if release.consumes %}
 	{% for link in release.consumes %}
-	<% if_link('{{ link }}') do |link| %>
 	cf set-env $1 {{ link | upper }}_HOST "${{ link | upper }}_HOST"
 	cf set-env $1 {{ link | upper }}_HOSTS "${{ link | upper }}_HOSTS"
 	cf set-env $1 {{ link | upper }}_PROPERTIES "${{ link | upper }}_PROPERTIES"
-	<% end %>
 	{% endfor %}
 	{% endfor %}
 

--- a/tile_generator/templates/jobs/opsmgr.env.erb
+++ b/tile_generator/templates/jobs/opsmgr.env.erb
@@ -36,7 +36,7 @@ ALLOW_PAID_SERVICE_PLANS=<%= properties.allow_paid_service_plans %>
 {% for link_name, link in release.consumes.iteritems() %}
 <% if_link('{{ link_name }}') do |link| %>
 <% hosts = link.instances.map { |instance| instance.address } %>
-{{ link_name | upper }}_HOST=<%= link.instances[0].address %>
+{{ link_name | upper }}_HOST=<%= link.instances.empty? ? ( puts "" ) : ( puts link.instances[0].address ) %>
 {{ link_name | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
 {{ link_name | upper }}_PROPERTIES=<% Shellwords.escape(link.properties.to_json) %>
 <% end %>

--- a/tile_generator/templates/jobs/opsmgr.env.erb
+++ b/tile_generator/templates/jobs/opsmgr.env.erb
@@ -32,14 +32,13 @@ ALLOW_PAID_SERVICE_PLANS=<%= properties.allow_paid_service_plans %>
 {% endfor %}
 {% endfor %}
 
-{% for release in context.releases if release.consumes %}
-{% for link in release.consumes %}
-<% if_link('{{ link }}') do |link| %>
+{% for release in context.releases.values() if release.consumes %}
+{% for link_name, link in release.consumes.iteritems() %}
+<% if_link('{{ link_name }}') do |link| %>
 <% hosts = link.instances.map { |instance| instance.address } %>
-{{ link | upper }}_HOST=<%= link.instances[0].address %>
-{{ link | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
-{{ link | upper }}_PROPERTIES=<% Shellwords.escape(link.properties.to_json) %>
+{{ link_name | upper }}_HOST=<%= link.instances[0].address %>
+{{ link_name | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
+{{ link_name | upper }}_PROPERTIES=<% Shellwords.escape(link.properties.to_json) %>
 <% end %>
-
 {% endfor %}
 {% endfor %}

--- a/tile_generator/templates/jobs/opsmgr.env.erb
+++ b/tile_generator/templates/jobs/opsmgr.env.erb
@@ -32,6 +32,8 @@ ALLOW_PAID_SERVICE_PLANS=<%= properties.allow_paid_service_plans %>
 {% endfor %}
 {% endfor %}
 
+<% empty_dict = {} %>
+<% empty_list = [] %>
 {% for release in context.releases.values() if release.consumes %}
 {% for link_name, link in release.consumes.iteritems() %}
 <% if_link('{{ link_name }}') do |link| %>
@@ -39,6 +41,10 @@ ALLOW_PAID_SERVICE_PLANS=<%= properties.allow_paid_service_plans %>
 {{ link_name | upper }}_HOST=<%= link.instances.empty? ? ( puts "" ) : ( puts link.instances[0].address ) %>
 {{ link_name | upper }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
 {{ link_name | upper }}_PROPERTIES=<% Shellwords.escape(link.properties.to_json) %>
+<% end.else do %>
+{{ link_name | upper }}_HOST=<%= Shellwords.escape(empty_list.to_json) %>
+{{ link_name | upper }}_HOSTS=<%= Shellwords.escape(empty_list.to_json) %>
+{{ link_name | upper }}_PROPERTIES=<% Shellwords.escape(empty_dict.to_json) %>
 <% end %>
 {% endfor %}
 {% endfor %}

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -115,6 +115,8 @@ consumes:
 {% for link_name, link in release.consumes.iteritems() %}
   - name: {{ link_name }}
     type: {{ link.type or link_name }}
-    optional: {{ link.optional if 'optional' in link else true }}
+{% if link.optional %}
+    optional: true
+{% endif %}
 {% endfor %}
 {% endfor %}

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -115,7 +115,7 @@ consumes:
 {% for link_name, link in release.consumes.iteritems() %}
   - name: {{ link_name }}
     type: {{ link.type or link_name }}
-{% if 'optional' in link and link.optional %}
+{% if link.optional is defined and link.optional %}
     optional: true
 {% endif %}
 {% endfor %}

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -112,9 +112,9 @@ properties:
 
 consumes:
 {% for release in context.releases.values() if release.consumes %}
-{% for link_type, link in release.consumes.iteritems() %}
-  - name: {{ link.name or link_type }}
-    type: {{ link_type }}
-    optional: {{ link.optional or true }}
+{% for link_name, link in release.consumes.iteritems() %}
+  - name: {{ link_name }}
+    type: {{ link.type or link_name }}
+    optional: {{ link.optional if 'optional' in link else true }}
 {% endfor %}
 {% endfor %}

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -115,7 +115,7 @@ consumes:
 {% for link_name, link in release.consumes.iteritems() %}
   - name: {{ link_name }}
     type: {{ link.type or link_name }}
-{% if link.optional %}
+{% if 'optional' in link and link.optional %}
     optional: true
 {% endif %}
 {% endfor %}

--- a/tile_generator/templates/tile/metadata.yml
+++ b/tile_generator/templates/tile/metadata.yml
@@ -437,11 +437,11 @@ job_types:
     release: {{ template.release }}
 {% if template.consumes %}
     consumes: |
-      {{ template.consumes | indent(6) }}
+      {{ template.consumes | yaml | indent(6) }}
 {% endif %}
 {% if template.provides %}
     provides: |
-      {{ template.provides | indent(6) }}
+      {{ template.provides | yaml | indent(6) }}
 {% endif %}
 {% endfor %}
   resource_definitions:
@@ -521,9 +521,9 @@ job_types:
   templates:
   - name: {{ job.type }}
     release: {{ release.release_name }}
-{% if release.consumes_cross_deployment %}
+{% if release.consumes_for_deployment %}
     consumes: |
-      {{ release.consumes_cross_deployment | yaml | indent(6) }}
+      {{ release.consumes_for_deployment | yaml | indent(6) }}
 {% endif %}
   resource_definitions:
   - name: ram


### PR DESCRIPTION
The following changes address issue #219 

* As per BOSH manifests the "consumes" dictionary is keyed on "name" and not "type"
* Ability for app-broker provided "consumes" to provide a "type"
** This type is used to generate the job spec, but is removed from the document manifest.
* The deployment manifest ( tile metadata ) produces all the "consumes" that have been provided.
* Set the link optionality to match the same defaults as per bosh links ( when 'optional' is not in the job spec, this means the link is required ).  So 'optional' is defaulted to False.  'optional' can be set to true
* Allow for handling of provided links that have been satisfied in the manifest, but at runtime can yield Zero addresses if number of job instances is set to 0.
* Allow for handing of missing links,   if_link(... ) else ...
* All this is  tested manually using the generated bosh releases directly on bosh-lite, with a variety of options. This is also tested on a PCF 1.12 deployment manually.
