### PR TITLE
Fix NameError caused by variable misspelling.

### DIFF
--- a/tile_generator/config.py
+++ b/tile_generator/config.py
@@ -285,9 +285,9 @@ class Config(dict):
 			if job.get('type') == 'deploy-all' and ExternalBroker in package_flags:
 				merge_dict(manifest, {
 					package['name']: {
-						'url': '(( .properties.{}_url.value ))'.format(pakage['name']),
-						'user': '(( .properties.{}_user.value ))'.format(pakage['name']),
-						'password': '(( .properties.{}_password.value ))'.format(pakage['name']),
+						'url': '(( .properties.{}_url.value ))'.format(package['name']),
+						'user': '(( .properties.{}_user.value ))'.format(package['name']),
+						'password': '(( .properties.{}_password.value ))'.format(package['name']),
 					}
 				})
 			elif job.get('type') == 'deploy-all' and Broker in package_flags:


### PR DESCRIPTION
Fixes this `NameError`:

```
tile build
Traceback (most recent call last):
  File "/home/brett/Development/virtualenvs/cloudfoundry/bin/tile", line 11, in <module>
    sys.exit(cli())
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/tile_generator/tile.py", line 56, in build_cmd
    cfg = Config().read()
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/tile_generator/config.py", line 108, in read
    self.transform()
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/tile_generator/config.py", line 129, in transform
    self.normalize_jobs()
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/tile_generator/config.py", line 250, in normalize_jobs
    job['manifest'] = self.build_job_manifest(job)
  File "/home/brett/Development/virtualenvs/cloudfoundry/lib/python2.7/site-packages/tile_generator/config.py", line 288, in build_job_manifest
    'url': '(( .properties.{}_url.value ))'.format(pakage['name']),
NameError: global name 'pakage' is not defined
```