### PR TITLE
Add support for helm package type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 site/
 /.dir-locals.el
 test_config_generated_output.json
+<<<<<<< HEAD
 .vscode/
+=======
+>>>>>>> TestUltimateForm: Save a generated output and sort keys for expected output

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,4 @@
 site/
 /.dir-locals.el
 test_config_generated_output.json
-<<<<<<< HEAD
 .vscode/
-=======
->>>>>>> TestUltimateForm: Save a generated output and sort keys for expected output

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 site/
 /.dir-locals.el
 test_config_generated_output.json
+.vscode/

--- a/ci/pipeline-helm.yml
+++ b/ci/pipeline-helm.yml
@@ -1,0 +1,97 @@
+---
+
+resources:
+
+- name: base-pipeline-docker-image
+  type: docker-image
+  source:
+    repository: cfplatformeng/tile-generator-pipeline
+    email: {{docker-hub-email}}
+    username: {{docker-hub-username}}
+    password: {{docker-hub-password}}
+
+- name: tile-generator-repo
+  type: git
+  source:
+    ignore_paths: [ "ci/docker-tile-generator", "ci/docker-tile-pipeline" ]
+    branch: helm
+    uri: http://github.com/cf-platform-eng/tile-generator.git
+
+- name: tile-generator-dockerfile-repo
+  type: git
+  source:
+    paths: [ "ci/docker-tile-generator" ]
+    branch: {{github-branch}}
+    uri: http://github.com/cf-platform-eng/tile-generator.git
+
+- name: tile-generator-docker-image
+  type: docker-image
+  source:
+    repository: cfplatformeng/tile-generator-helm
+    email: {{docker-hub-email}}
+    username: {{docker-hub-username}}
+    password: {{docker-hub-password}}
+
+jobs:
+
+- name: unit-tests
+  plan:
+  - aggregate:
+    - get: base-pipeline-docker-image
+    - get: tile-generator-repo
+      trigger: true
+  - task: run-unit-tests
+    image: base-pipeline-docker-image
+    config:
+      platform: linux
+      inputs:
+      - name: tile-generator-repo
+      run:
+        path: tile-generator-repo/ci/scripts/run-unittests.sh
+        args: [ "tile-generator-repo/tile_generator" ]
+
+- name: package-tile-generator
+  plan:
+  - aggregate:
+    - get: base-pipeline-docker-image
+      passed: [ unit-tests ]
+      trigger: true
+    - get: tile-generator-repo
+      passed: [ unit-tests ]
+      trigger: true
+    - get: tile-generator-dockerfile-repo
+      trigger: true
+  - task: build-package
+    image: base-pipeline-docker-image
+    config:
+      platform: linux
+      inputs:
+      - name: tile-generator-repo
+      outputs:
+      - name: tile-generator-package
+      run:
+        path: sh
+        args:
+        - -exc 
+        - |
+          cd tile-generator-repo
+          echo "0.9" >version.txt
+          python setup.py sdist
+          cp dist/tile-generator-*.tar.gz ../tile-generator-package/tile-generator-helm-0.9.tar.gz
+  - task: prepare-docker-build
+    image: base-pipeline-docker-image
+    config:
+      platform: linux
+      inputs:
+      - name: tile-generator-dockerfile-repo
+      - name: tile-generator-package
+      outputs:
+      - name: docker-build-dir
+      run:
+        path: sh
+        args:
+        - -c
+        - cp tile-generator-package/* docker-build-dir/ && cp tile-generator-dockerfile-repo/ci/docker-tile-generator/* docker-build-dir/
+  - put: tile-generator-docker-image
+    params:
+      build: docker-build-dir

--- a/tile_generator/bosh.py
+++ b/tile_generator/bosh.py
@@ -124,12 +124,14 @@ class BoshRelease:
 		requires_cf_cli = job.get('requires_cf_cli', False)
 		is_errand = job.get('lifecycle', None) == 'errand'
 		package = job.get('package', None)
+		packages = job.get('packages', [])
 		self.__bosh('generate-job', job_type)
 		job_context = {
 			'job_name': job_name,
 			'job_type': job_type,
 			'context': self.context,
 			'package': package,
+			'packages': packages,
 			'errand': is_errand,
 			'requires_cf_cli': requires_cf_cli
 		}

--- a/tile_generator/bosh.py
+++ b/tile_generator/bosh.py
@@ -155,7 +155,7 @@ class BoshRelease:
 		)
 
 	def needs_zip(self, package):
-		# Only zip CF packages...
+		# Only zip package types that require single files
 		if not package.get('is_cf', False) and not package.get('zip_if_needed', False):
 			return False
 		files = package['files']

--- a/tile_generator/bosh.py
+++ b/tile_generator/bosh.py
@@ -121,6 +121,7 @@ class BoshRelease:
 		job_name = job['name']
 		job_type = job.get('type', job_name)
 		job_template = job.get('template', job_type)
+		requires_cf_cli = job.get('requires_cf_cli', False)
 		is_errand = job.get('lifecycle', None) == 'errand'
 		package = job.get('package', None)
 		self.__bosh('generate-job', job_type)
@@ -130,6 +131,7 @@ class BoshRelease:
 			'context': self.context,
 			'package': package,
 			'errand': is_errand,
+			'requires_cf_cli': requires_cf_cli
 		}
 		template.render(
 			os.path.join(self.release_dir, 'jobs', job_type, 'spec'),
@@ -154,7 +156,7 @@ class BoshRelease:
 
 	def needs_zip(self, package):
 		# Only zip CF packages...
-		if not package.get('is_cf', False):
+		if not package.get('is_cf', False) and not package.get('zip_if_needed', False):
 			return False
 		files = package['files']
 		# ...if it has more than one file...
@@ -164,6 +166,7 @@ class BoshRelease:
 		elif len(files) == 1:
 			return not zipfile.is_zipfile(files[0]['path'])
 		return False
+
 	def add_blob(self,package):
 		for file in package ['files']:
 			self.__bosh('add-blob',os.path.realpath(file['path']),file['name'])
@@ -184,7 +187,7 @@ class BoshRelease:
 			staging_dir = tempfile.mkdtemp()
 			for file in package.get('files', []):
 				download(file['path'], os.path.join(staging_dir, file['name']), cache=self.context.get('cache', None))
-			path = package['manifest'].get('path', '')
+			path = package.get('manifest', {}).get('path', '')
 			dir_to_zip = os.path.join(staging_dir, path) if path else staging_dir
 			zipfilename = os.path.realpath(os.path.join(target_dir, package['name'] + '.zip'))
 			zip_dir(zipfilename, dir_to_zip)

--- a/tile_generator/config.py
+++ b/tile_generator/config.py
@@ -319,7 +319,7 @@ class Config(dict):
 			manifest[service_plan_form['name']] = '(( .properties.{}.value ))'.format(service_plan_form['name'])
 		for package in self.get('packages', []):
 			package_flags = self._get_package_def(package).flags
-			merge_dict(manifest, package['properties'])
+			merge_dict(manifest, package.get('properties', {}))
 			if job.get('type') == 'deploy-all' and ExternalBroker in package_flags:
 				merge_dict(manifest, {
 					package['name']: {

--- a/tile_generator/helm.py
+++ b/tile_generator/helm.py
@@ -15,7 +15,7 @@ def find_required_images(values):
                 image = value
                 tag = values.get('tag', values.get('imagetag', None))
             if tag is not None:
-                image += ':' + tag
+                image += ':' + str(tag)
             images += [ image ]
         else:
             if isinstance(value, dict):

--- a/tile_generator/helm.py
+++ b/tile_generator/helm.py
@@ -5,14 +5,15 @@ import json
 
 def find_required_images(values):
     images = []
+    values = { k.lower():v for k,v in values.items() }
     for key, value in values.items():
         if key == 'image':
             if isinstance(value, dict):
                 image = value.get('repository')
-                tag = value.get('tag', None)
+                tag = value.get('tag', value.get('imagetag', None))
             else:
                 image = value
-                tag = values.get('imageTag', None)
+                tag = values.get('tag', values.get('imagetag', None))
             if tag is not None:
                 image += ':' + tag
             images += [ image ]
@@ -30,8 +31,8 @@ def get_chart_info(chart_dir):
         chart_values = yaml.safe_load(f)
 
     return {
-        'name': chart['name'],
-        'version': chart['version'],
+        'name': chart.get('name', chart.get('Name')),
+        'version': chart.get('version', chart.get('Version')),
         'required_images': find_required_images(chart_values),
     }
 

--- a/tile_generator/helm.py
+++ b/tile_generator/helm.py
@@ -9,7 +9,7 @@ def find_required_images(values):
     for key, value in values.items():
         if key == 'image':
             if isinstance(value, dict):
-                image = value.get('repository')
+                image = value.get('repository', value.get('name'))
                 tag = value.get('tag', value.get('imagetag', None))
             else:
                 image = value

--- a/tile_generator/helm.py
+++ b/tile_generator/helm.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import yaml
+import json
+
+def find_required_images(values):
+    images = []
+    for key, value in values.items():
+        if key == 'image':
+            if isinstance(value, dict):
+                image = value.get('repository')
+                tag = value.get('tag', None)
+            else:
+                image = value
+                tag = values.get('imageTag', None)
+            if tag is not None:
+                image += ':' + tag
+            images += [ image ]
+        else:
+            if isinstance(value, dict):
+                images += find_required_images(value)
+    return images
+
+def get_chart_info(chart_dir):
+    chart_file = os.path.join(chart_dir, 'Chart.yaml')
+    with open(chart_file) as f:
+        chart = yaml.safe_load(f)
+    values_file = os.path.join(chart_dir, 'values.yaml')
+    with open(values_file) as f:
+        chart_values = yaml.safe_load(f)
+
+    return {
+        'name': chart['name'],
+        'version': chart['version'],
+        'required_images': find_required_images(chart_values),
+    }
+
+if __name__ == '__main__':
+    for chart in sys.argv[1:]:
+        print(json.dumps(get_chart_info(chart), indent=4))

--- a/tile_generator/helm.py
+++ b/tile_generator/helm.py
@@ -7,10 +7,13 @@ def find_required_images(values):
     images = []
     values = { k.lower():v for k,v in values.items() }
     for key, value in values.items():
-        if key == 'image':
+        if key in [ 'image', 'repository' ]:
             if isinstance(value, dict):
                 image = value.get('repository', value.get('name'))
                 tag = value.get('tag', value.get('imagetag', None))
+                if image is None:
+                    images += find_required_images(value)
+                    continue
             else:
                 image = value
                 tag = values.get('tag', values.get('imagetag', None))

--- a/tile_generator/helm.py
+++ b/tile_generator/helm.py
@@ -5,7 +5,7 @@ import json
 
 def find_required_images(values):
     images = []
-    values = { k.lower():v for k,v in values.items() }
+    values = values is not None and { k.lower():v for k,v in values.items() } or {}
     for key, value in values.items():
         if key in [ 'image', 'repository' ]:
             if isinstance(value, dict):

--- a/tile_generator/helm_unittest.py
+++ b/tile_generator/helm_unittest.py
@@ -1,0 +1,116 @@
+import unittest
+from . import helm
+
+class TestImageFinder(unittest.TestCase):
+
+    def test_finds_top_level_image(self):
+        values = {
+            'image': 'foo/bar',
+            'tag': 1.2
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_top_level_image_uppercase(self):
+        values = {
+            'Image': 'foo/bar',
+            'Tag': 1.2
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_top_level_image_using_repository(self):
+        values = {
+            'repository': 'foo/bar',
+            'tag': 1.2
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_top_level_image_using_imagetag(self):
+        values = {
+            'image': 'foo/bar',
+            'imagetag': 1.2
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_nested_image(self):
+        values = {
+            'level1': {
+                'level2': {
+                    'image': 'foo/bar',
+                    'tag': 1.2
+                }
+            }
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_nested_image_uppercase(self):
+        values = {
+            'level1': {
+                'level2': {
+                    'Image': 'foo/bar',
+                    'Tag': 1.2
+                }
+            }
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_nested_image_using_repository(self):
+        values = {
+            'level1': {
+                'level2': {
+                    'repository': 'foo/bar',
+                    'tag': 1.2
+                }
+            }
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_nested_image_using_imagetag(self):
+        values = {
+            'level1': {
+                'level2': {
+                    'image': 'foo/bar',
+                    'imagetag': 1.2
+                }
+            }
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_nested_image_using_imagetag(self):
+        values = {
+            'level1': {
+                'level2': {
+                    'image': 'foo/bar',
+                    'imagetag': 1.2
+                }
+            }
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_finds_nested_image_in_image(self): # Case found in fluent-bit helm chart
+        values = {
+            'image': {
+                'image': 'foo/bar',
+                'imagetag': 1.2
+            }
+        }
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 1)
+        self.assertEqual(images[0], "foo/bar:1.2")

--- a/tile_generator/helm_unittest.py
+++ b/tile_generator/helm_unittest.py
@@ -114,3 +114,8 @@ class TestImageFinder(unittest.TestCase):
         images = helm.find_required_images(values)
         self.assertEqual(len(images), 1)
         self.assertEqual(images[0], "foo/bar:1.2")
+
+    def test_handles_empty_values(self): # Case found in weave-cloud helm chart
+        values = None
+        images = helm.find_required_images(values)
+        self.assertEqual(len(images), 0)

--- a/tile_generator/package_definitions.py
+++ b/tile_generator/package_definitions.py
@@ -155,3 +155,13 @@ class PackageDockerAppBroker(BasePackage):
 class PackageBlob(BasePackage):
     package_type = 'blob'
     flags = [flag.Cf] # flag.Blob
+
+
+class PackageHelm(BasePackage):
+    package_type = 'helm'
+    flags = [flag.Helm]
+    _schema = {
+        'name': {'type': 'string', 'required': True },
+        'path': {'type': 'string', 'required': True },
+        'zip_if_needed': {'type': 'boolean', 'default': True}
+    }

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -275,8 +275,10 @@ class Helm(FlagBase):
         for image in chart_info['required_images']:
             image_name = image.split('/')[-1]
             image_package_name = package['name'] + '-images'
-            image_package = ([p for p in release['packages'] if p['name'] == image_package_name] + [ None ])[0]
-            if image_package is None:
+            image_packages = [p for p in release['packages'] if p['name'] == image_package_name]
+            if image_packages:
+                image_package = image_packages[0]
+            else:
                 image_package = {
                     'name': image_package_name,
                     'files': [],

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -289,12 +289,16 @@ class Helm(FlagBase):
             }]
         # Add errands if they are not already here
         if 'deploy-charts' not in [job['name'] for job in release['jobs']]:
-            release['jobs'] += [{
+            deploy_charts_job = {
                 'name': 'deploy-charts',
                 'type': 'deploy-charts',
                 'lifecycle': 'errand',
                 'post_deploy': True
-            }]
+            }
+            if image_package is not None:
+                deploy_charts_job['packages'] = deploy_charts_job.get('packages',[])
+                deploy_charts_job['packages'] += [ image_package ]
+            release['jobs'] += [ deploy_charts_job ]
         if 'delete-charts' not in [job['name'] for job in release['jobs']]:
             release['jobs'] += [{
                 'name': 'delete-charts',

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -274,13 +274,18 @@ class Helm(FlagBase):
         chart_info = helm.get_chart_info(package['path'])
         for image in chart_info['required_images']:
             image_name = image.split('/')[-1]
-            release['packages'] += [{
+            image_package_name = package['name'] + '-images'
+            image_package = ([p for p in release['packages'] if p['name'] == image_package_name] + [ None ])[0]
+            if image_package is None:
+                image_package = {
+                    'name': image_package_name,
+                    'files': [],
+                    'dir': 'blobs'
+                }
+                release['packages'] += [ image_package ]
+            image_package['files'] += [{
                 'name': image_name,
-                'files': [{
-                    'name': image_name,
-                    'path': 'docker:' + image
-                }],
-                'dir': 'blobs'
+                'path': 'docker:' + image
             }]
         # Add errands if they are not already here
         if 'deploy-charts' not in [job['name'] for job in release['jobs']]:

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -288,6 +288,9 @@ class Helm(FlagBase):
         if { 'name': 'delete-charts' } not in config_obj.get('pre_delete_errands', []):
             config_obj['pre_delete_errands'] = config_obj.get('pre_delete_errands', []) + [{ 'name': 'delete-charts' }]
         if False:
+            # Turning this off for now until we figure out the real dependencies for the errands
+            if not 'helm_cli' in [p['name'] for p in release['packages']]:
+                release['packages'] += []
             # Turning this off for now so that the tile can be installed in foundations that don't have PKS for testing
             config_obj.tile_metadata['requires_product_versions'] = config_obj.get('requires_product_versions', []) + [
                 {

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -80,14 +80,16 @@ class Cf(FlagBase):
                 'name': 'deploy-all',
                 'type': 'deploy-all',
                 'lifecycle': 'errand',
-                'post_deploy': True
+                'post_deploy': True,
+                'requires_cf_cli': True
             }]
         if 'delete-all' not in [job['name'] for job in release['jobs']]:
             release['jobs'] += [{
                 'name': 'delete-all',
                 'type': 'delete-all',
                 'lifecycle': 'errand',
-                'pre_delete': True
+                'pre_delete': True,
+                'requires_cf_cli': True
             }]
         if { 'name': 'deploy-all' } not in config_obj.get('post_deploy_errands', []):
             config_obj['post_deploy_errands'] = config_obj.get('post_deploy_errands', []) + [{ 'name': 'deploy-all' }]
@@ -263,3 +265,33 @@ class Buildpack(FlagBase):
             'buildpack_order': '(( .properties.{}_buildpack_order.value ))'.format(packagename),
         })
         package['properties'] = properties
+
+class Helm(FlagBase):
+    @classmethod
+    def _apply(self, config_obj, package, release):
+        if 'deploy-charts' not in [job['name'] for job in release['jobs']]:
+            release['jobs'] += [{
+                'name': 'deploy-charts',
+                'type': 'deploy-charts',
+                'lifecycle': 'errand',
+                'post_deploy': True
+            }]
+        if 'delete-charts' not in [job['name'] for job in release['jobs']]:
+            release['jobs'] += [{
+                'name': 'delete-charts',
+                'type': 'delete-charts',
+                'lifecycle': 'errand',
+                'pre_delete': True
+            }]
+        if { 'name': 'deploy-charts' } not in config_obj.get('post_deploy_errands', []):
+            config_obj['post_deploy_errands'] = config_obj.get('post_deploy_errands', []) + [{ 'name': 'deploy-charts' }]
+        if { 'name': 'delete-charts' } not in config_obj.get('pre_delete_errands', []):
+            config_obj['pre_delete_errands'] = config_obj.get('pre_delete_errands', []) + [{ 'name': 'delete-charts' }]
+        if False:
+            # Turning this off for now so that the tile can be installed in foundations that don't have PKS for testing
+            config_obj.tile_metadata['requires_product_versions'] = config_obj.get('requires_product_versions', []) + [
+                {
+                    'name': 'pivotal-container-service',
+                    'version': '>= 0.8'
+                }
+            ]

--- a/tile_generator/templates/jobs/delete-charts.sh.erb
+++ b/tile_generator/templates/jobs/delete-charts.sh.erb
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# TBD - Delete all helm charts deployed by this release

--- a/tile_generator/templates/jobs/deploy-charts.sh.erb
+++ b/tile_generator/templates/jobs/deploy-charts.sh.erb
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# TBD - Deploy all helm charts in this release

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -10,7 +10,9 @@ templates:
 {% endif %}
 packages:
 {% if not package %}
+{% if requires_cf_cli %}
 - cf_cli
+{% endif %}
 {% for package in context.packages if not package.is_bosh_release %}
 - {{ package.name }}
 {% endfor %}

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -16,6 +16,9 @@ packages:
 {% for package in context.packages if not package.is_bosh_release %}
 - {{ package.name }}
 {% endfor %}
+{% for package in packages %}
+- {{ package.name }}
+{% endfor %}
 {% else %}
 {% if package.requires_cf_cli %}
 - cf_cli

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -2670,6 +2670,7 @@
           "name": "deploy-all", 
           "post_deploy": true, 
           "properties": {}, 
+          "requires_cf_cli": true, 
           "template": "deploy-all", 
           "type": "deploy-all"
         }, 
@@ -2830,6 +2831,7 @@
           "name": "delete-all", 
           "pre_delete": true, 
           "properties": {}, 
+          "requires_cf_cli": true, 
           "template": "delete-all", 
           "type": "delete-all"
         }, 

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -1454,6 +1454,7 @@
           "properties": {},
           "name": "deploy-all",
           "post_deploy": true,
+          "requires_cf_cli": true,
           "manifest": {
             "tg_test_app6": {
               "name": "tg_test_app6"
@@ -1620,6 +1621,7 @@
         },
         {
           "pre_delete": true,
+          "requires_cf_cli": true,
           "manifest": {
             "tg_test_app6": {
               "name": "tg_test_app6"

--- a/tile_generator/util.py
+++ b/tile_generator/util.py
@@ -88,6 +88,7 @@ def download(url, filename, cache=None):
 		try:
 			from docker.client import Client
 			docker_cli = Client.from_env()
+			docker_cli.pull(docker_image)
 			image = docker_cli.get_image(docker_image)
 			image_tar = open(filename,'w')
 			image_tar.write(image.data)
@@ -95,7 +96,8 @@ def download(url, filename, cache=None):
 		except KeyError as e:
 			print('docker not configured on this machine (or environment variables are not properly set)', file=sys.stderr)
 			sys.exit(1)
-		except:
+		except Exception as e:
+			print(e)
 			print(docker_image, 'not found on local machine', file=sys.stderr)
 			print('you must either pull the image, or download it and use the --cache option', file=sys.stderr)
 			sys.exit(1)


### PR DESCRIPTION
Roughed in support for helm packages. Not functional yet!!

Most of the changes are out of the mainline and only affect the new package type, but there are a couple of things I had to hack into the mainline to get it to work:
- pull docker images instead of just saving them
- allow per-job package dependencies
- make cf_cli dependency optional in the job spec
- extend zip support to package types other than just cf
- make manifest and package properties optional

Some of these changes support more general refactoring (we should use zip_if_needed for the cf type packages, for instance, and get rid of the other test), but the TestUltimateForm really gets in the way of that, as it results to a large number of changes in the config object.

If we can merge these, we can continue development of helm support in master without too much risk to existing package types, and avoid a difficult merge down the road.