### PR TITLE
Fix async auto-service support

### DIFF
--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -206,8 +206,8 @@ function delete_older_versions() {
 
 function wait_til_service_running() {
 	for i in `seq 1 40`; do
-		STATUS=$(cf service $1 | grep "Status:")
-		if [ "$STATUS" = "Status: create in progress" ]; then
+		STATUS=$($CF service $1 | grep -i "status:")
+		if [[ "$STATUS" =~ "create in progress" ]]; then
 			echo "cf service $1 shows '$STATUS'. Waiting..."
 			sleep 30
 		else


### PR DESCRIPTION
The output of `cf service SERVICE_INSTANCE` changed which broke
the `wait_til_service_running` function. This commit makes
the check for the service instance status case insensitive
and white space agnostic.

I had problems using the `cf` function so I'm using `$CF` similar to
what other code in this script is using.