### PR TITLE
BOSH major version is 3.0 now, fix version checking so >1 works rather than ==2

### DIFF
--- a/tile_generator/bosh.py
+++ b/tile_generator/bosh.py
@@ -236,7 +236,7 @@ def ensure_bosh():
 
 	if bosh_exec:
 		output = subprocess.check_output(["bosh", "--version"], stderr=subprocess.STDOUT, cwd=".")
-		if not output.startswith("version 2."):
+		if output.startswith("version 1."):
 			print("You are running older bosh version. Please upgrade to 'bosh 2.0' command should be on the path. See https://bosh.io/docs/cli-v2.html for installation instructions")
 			sys.exit(1)
 


### PR DESCRIPTION
Fixes #245 