### PR TITLE
Add pre-start, UAA admin client, and fix for BOSH CLI v3

### DIFF
--- a/tile_generator/bosh.py
+++ b/tile_generator/bosh.py
@@ -236,8 +236,8 @@ def ensure_bosh():
 
 	if bosh_exec:
 		output = subprocess.check_output(["bosh", "--version"], stderr=subprocess.STDOUT, cwd=".")
-		if not output.startswith("version 2."):
-			print("You are running older bosh version. Please upgrade to 'bosh 2.0' command should be on the path. See https://bosh.io/docs/cli-v2.html for installation instructions")
+		if not output.startswith("version 2.") and not output.startswith("version 3."):
+			print("You are running older bosh version. Please upgrade to bosh 2.0 or later. See https://bosh.io/docs/cli-v2.html for installation instructions")
 			sys.exit(1)
 
 def run_bosh(working_dir, *argv, **kw):

--- a/tile_generator/config.py
+++ b/tile_generator/config.py
@@ -295,6 +295,10 @@ class Config(dict):
 				'admin_user': '(( ..cf.uaa.system_services_credentials.identity ))',
 				'admin_password': '(( ..cf.uaa.system_services_credentials.password ))',
 			},
+			'uaa': {
+				'admin_client': '(( ..cf.uaa.admin_client_credentials.identity ))',
+				'admin_client_secret': '(( ..cf.uaa.admin_client_credentials.password ))',
+			},
 			'apply_open_security_group': '(( .properties.apply_open_security_group.value ))',
 			'allow_paid_service_plans': '(( .properties.allow_paid_service_plans.value ))',
 		}

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -189,7 +189,9 @@ class App(FlagBase):
             config_obj['compilation_vm_disk_size'] = max(
                 config_obj['compilation_vm_disk_size'],
                 4 * _update_compilation_vm_disk_size(manifest))
-
+        if package.get('pre_start_file'):
+            with open(package.get('pre_start_file'),'r') as f:
+                package['pre_start'] = f.read();
         packagename = package['name']
         properties = package.get('properties', {packagename: {}})
         properties[packagename].update(

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -402,6 +402,10 @@ export NEEDS_CF_CREDS="{{ package.needs_cf_credentials }}"
 export HEALTH_CHECK="{{ package.health_check }}"
 deploy_app "$PKG_NAME" "$APP_NAME" "$APP_HOST" "$DOCKER_IMAGE" "$NEEDS_CF_CREDS" "$HEALTH_CHECK" <%= Shellwords.escape(p('{{ package.name }}.app_manifest').to_json) %>
 
+{% if package.pre_start %}
+{{ package.pre_start | render }}
+{% endif %}
+
 <% p('{{ package.name }}.auto_services').each do |service| %>
 export SVC_NAME="<%= service['name'] %>"
 export SVC_PLAN="<%= service.fetch('plan', '') %>"

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -35,6 +35,8 @@ function import_opsmgr_variables() {
 	export SECURITY_USER_PASSWORD={{ 'properties.security.password' | shell_string }}
 	export APPLY_OPEN_SECURITY_GROUP={{ 'properties.apply_open_security_group' | shell_string }}
 	export ALLOW_PAID_SERVICE_PLANS={{ 'properties.allow_paid_service_plans' | shell_string }}
+	export UAA_ADMIN_CLIENT=<%= properties.uaa.admin_client %>
+	export UAA_ADMIN_CLIENT_SECRET=<%= properties.uaa.admin_client_secret %>
 
 	{% for service_plan_form in context.service_plan_forms %}
 	{{ service_plan_form | plans_json | indent }}

--- a/tile_generator/templates/jobs/opsmgr.env.erb
+++ b/tile_generator/templates/jobs/opsmgr.env.erb
@@ -11,6 +11,8 @@ SECURITY_USER_NAME=<%= properties.security.user %>
 SECURITY_USER_PASSWORD=<%= properties.security.password %>
 APPLY_OPEN_SECURITY_GROUP=<%= properties.apply_open_security_group %>
 ALLOW_PAID_SERVICE_PLANS=<%= properties.allow_paid_service_plans %>
+UAA_ADMIN_CLIENT=<%= properties.uaa.admin_client %>
+UAA_ADMIN_CLIENT_SECRET=<%= properties.uaa.admin_client_secret %>
 
 {% for service_plan_form in context.service_plan_forms %}
 {{ service_plan_form | plans_json(false, false) }}

--- a/tile_generator/templates/jobs/spec
+++ b/tile_generator/templates/jobs/spec
@@ -41,6 +41,10 @@ properties:
     description: 'Username of the CF admin user'
   cf.admin_password:
     description: 'Password of the CF admin user'
+  uaa.admin_client:
+    description: 'Name of the UAA Admin Client'
+  uaa.admin_client_secret:
+    description: 'Password of the UAA Admin Client'
   apply_open_security_group:
     description: 'Open security group for the app to access outside'
     default: false


### PR DESCRIPTION
Hey all,

We needed to make some extensions to the deploy-all script to support our broker creating its own UAA client. To do so we had to pull in the UAA admin client from CF, and added a pre-start hook so we could get our apps GUID.

Let us know if you have any questions/comments about this, we can optionally split up the PR if you want.

Thanks,
Ben & Anna