### PR TITLE
Fix arguments for `cf delete`

### DIFF
--- a/tile_generator/templates/jobs/delete-all.sh.erb
+++ b/tile_generator/templates/jobs/delete-all.sh.erb
@@ -79,7 +79,7 @@ function delete_empty_org() {
 
 function delete_all_versions() {
 	$CF apps | grep "^$1-" | while read app rest; do
-		cf delete -rf $app
+		cf delete -r -f $app
 	done
 }
 


### PR DESCRIPTION
When running the `delete-all` errand, we see the following error:

```
cf delete -rf <my-app>  
           FAILED  
           Incorrect Usage  
             
           Invalid flag: -rf  
             
           NAME:  
              delete - Delete an app  
             
           USAGE:  
              cf delete APP_NAME [-f -r]  
             
           ALIAS:  
              d  
             
           OPTIONS:  
              -f      Force deletion without confirmation  
              -r      Also delete any mapped routes
```