### PR TITLE
162353515 pcf bosh env fails on 2 3

### DIFF
--- a/tile_generator/pcf.py
+++ b/tile_generator/pcf.py
@@ -448,13 +448,12 @@ def credentials_cmd():
 
 @cli.command('bosh-env')
 def bosh_env_cmd():
-	version = opsmgr.get_version()
 	director_creds = opsmgr.get('/api/v0/deployed/director/credentials/director_credentials').json()
 	director_manifest = opsmgr.get('/api/v0/deployed/director/manifest').json()
-	if version[0] >= 2 and version[1] >= 3:
-		director_address = director_manifest['instance_groups'][0]['properties']['director']['address']
-	else:
-		director_address = director_manifest['jobs'][0]['properties']['director']['address']
+
+	# PCF 2.2 and earlier has 'jobs' array at top level, while
+	# PCF 2.3 and later has 'instance_groups'
+	director_address = director_manifest.get('instance_groups', director_manifest.get('jobs'))[0]['properties']['director']['address']
 
 	click.echo('BOSH_ENVIRONMENT="%s"' % director_address)
 	click.echo('BOSH_CA_CERT="/var/tempest/workspaces/default/root_ca_certificate"')

--- a/tile_generator/pcf_unittest.py
+++ b/tile_generator/pcf_unittest.py
@@ -1,0 +1,94 @@
+# tile-generator
+#
+# Copyright (c) 2015-Present Pivotal Software, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+import unittest
+import mock
+import requests
+from io import BytesIO
+from .pcf import bosh_env_cmd
+from click.testing import CliRunner
+
+
+def build_response(body, encoding='application/json', status_code=200):
+    response = requests.Response()
+    response.status_code = status_code
+    response.encoding = encoding
+    response.raw = BytesIO(body)
+    response.request = requests.Request()
+    response.request.url = 'https://example.com/'
+    return response
+
+
+@mock.patch('tile_generator.opsmgr.get')
+@mock.patch('tile_generator.opsmgr.get_version')
+class TestBoshEnvCmd(unittest.TestCase):
+    def test_pcf_2_2_uses_jobs(self, mock_get_version, mock_get):
+        mock_get.side_effect = [
+            build_response(opsmgr_responses['/api/v0/deployed/director/credentials/director_credentials']),
+            build_response(opsmgr_responses['2.2 /api/v0/deployed/director/manifest'])
+        ]
+        mock_get_version.side_effect = [
+            [2, 2, 0]
+        ]
+
+        # Since bosh_env_cmd is wrapped by a @cli.command, we need to invoke it this way
+        runner = CliRunner()
+        result = runner.invoke(bosh_env_cmd, [])
+
+        self.assertIn('BOSH_ENVIRONMENT="10.0.0.5"', result.output)
+        self.assertIn('BOSH_CA_CERT="/var/tempest/workspaces/default/root_ca_certificate"', result.output)
+        self.assertIn('BOSH USERNAME=director', result.output)
+        self.assertIn('BOSH PASSWORD=super-secret-password', result.output)
+
+    def test_pcf_2_3_uses_jobs(self, mock_get_version, mock_get):
+        mock_get.side_effect = [
+            build_response(opsmgr_responses['/api/v0/deployed/director/credentials/director_credentials']),
+            build_response(opsmgr_responses['2.3 /api/v0/deployed/director/manifest'])
+        ]
+        mock_get_version.side_effect = [
+            [2, 3, 0]
+        ]
+
+        # Since bosh_env_cmd is wrapped by a @cli.command, we need to invoke it this way
+        runner = CliRunner()
+        result = runner.invoke(bosh_env_cmd, [])
+
+        self.assertIn('BOSH_ENVIRONMENT="10.0.0.6"', result.output)
+        self.assertIn('BOSH_CA_CERT="/var/tempest/workspaces/default/root_ca_certificate"', result.output)
+        self.assertIn('BOSH USERNAME=director', result.output)
+        self.assertIn('BOSH PASSWORD=super-secret-password', result.output)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+opsmgr_responses = {}
+opsmgr_responses['/api/v0/deployed/director/credentials/director_credentials'] = """{
+  "credential": {
+    "type": "simple_credentials",
+    "value": {
+      "password": "super-secret-password",
+      "identity": "director"
+    }
+  }
+}"""
+opsmgr_responses['2.2 /api/v0/deployed/director/manifest'] = """{
+  "jobs": [ { "properties": { "director": { "address": "10.0.0.5" } } } ]
+}"""
+opsmgr_responses['2.3 /api/v0/deployed/director/manifest'] = """{
+  "instance_groups": [ { "properties": { "director": { "address": "10.0.0.6" } } } ]
+}"""

--- a/tile_generator/pcf_unittest.py
+++ b/tile_generator/pcf_unittest.py
@@ -34,15 +34,11 @@ def build_response(body, encoding='application/json', status_code=200):
 
 
 @mock.patch('tile_generator.opsmgr.get')
-@mock.patch('tile_generator.opsmgr.get_version')
 class TestBoshEnvCmd(unittest.TestCase):
-    def test_pcf_2_2_uses_jobs(self, mock_get_version, mock_get):
+    def test_pcf_2_2_uses_jobs(self, mock_get):
         mock_get.side_effect = [
             build_response(opsmgr_responses['/api/v0/deployed/director/credentials/director_credentials']),
             build_response(opsmgr_responses['2.2 /api/v0/deployed/director/manifest'])
-        ]
-        mock_get_version.side_effect = [
-            [2, 2, 0]
         ]
 
         # Since bosh_env_cmd is wrapped by a @cli.command, we need to invoke it this way
@@ -54,13 +50,10 @@ class TestBoshEnvCmd(unittest.TestCase):
         self.assertIn('BOSH USERNAME=director', result.output)
         self.assertIn('BOSH PASSWORD=super-secret-password', result.output)
 
-    def test_pcf_2_3_uses_instance_groups(self, mock_get_version, mock_get):
+    def test_pcf_2_3_uses_instance_groups(self, mock_get):
         mock_get.side_effect = [
             build_response(opsmgr_responses['/api/v0/deployed/director/credentials/director_credentials']),
             build_response(opsmgr_responses['2.3 /api/v0/deployed/director/manifest'])
-        ]
-        mock_get_version.side_effect = [
-            [2, 3, 0]
         ]
 
         # Since bosh_env_cmd is wrapped by a @cli.command, we need to invoke it this way

--- a/tile_generator/pcf_unittest.py
+++ b/tile_generator/pcf_unittest.py
@@ -54,7 +54,7 @@ class TestBoshEnvCmd(unittest.TestCase):
         self.assertIn('BOSH USERNAME=director', result.output)
         self.assertIn('BOSH PASSWORD=super-secret-password', result.output)
 
-    def test_pcf_2_3_uses_jobs(self, mock_get_version, mock_get):
+    def test_pcf_2_3_uses_instance_groups(self, mock_get_version, mock_get):
         mock_get.side_effect = [
             build_response(opsmgr_responses['/api/v0/deployed/director/credentials/director_credentials']),
             build_response(opsmgr_responses['2.3 /api/v0/deployed/director/manifest'])


### PR DESCRIPTION
Fix the bosh-env command so that it works on PCF 2.3+

* Add unit tests to validate changes
* Convert print statements in pcf.py to click.echo for consistency

Co-authored-by Mikey Boldt <mboldt@pivotal.io>
Co-authored-by Krsna Mahapatra <kmahapatra@pivotal.io>