### PR TITLE
Update BOSH CLI version in Dockerfile, closes #290

### DIFF
--- a/ci/docker-tile-generator/Dockerfile
+++ b/ci/docker-tile-generator/Dockerfile
@@ -14,8 +14,8 @@ RUN apk add --no-cache zip &&\
     apk del build-dependencies
 
 
-RUN wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.23-linux-amd64
-RUN mv bosh-cli-2.0.23-linux-amd64 /usr/local/bin/bosh
+RUN wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-5.4.0-linux-amd64
+RUN mv bosh-cli-5.4.0-linux-amd64 /usr/local/bin/bosh
 RUN chmod 755 /usr/local/bin/bosh
 
 RUN wget -O /tmp/cf.tgz https://packages.cloudfoundry.org/stable?release=linux64-binary


### PR DESCRIPTION
Reason for PR:
I'm using the Docker image [cfplatformeng/tile-generator](https://hub.docker.com/r/cfplatformeng/tile-generator) for building tiles (and subsequently BOSH releases) for my own concourse pipelines.

Docker file builds up to the COPY step.
I haven't tested further (Replicating the concourse pipeline is a pain)

