### PR TITLE
fix tile_metadata.py python3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
 		'requests>2.11',
 		'requests-toolbelt',
 		'mock>=2.0.0',
-		'pexpect>=4.2.1'
+		'pexpect>=4.2.1',
+		'helm'
 	],
 	include_package_data = True,
 	entry_points = {

--- a/tile_generator/tile_metadata.py
+++ b/tile_generator/tile_metadata.py
@@ -1,9 +1,14 @@
 import yaml
 from . import template as template_helper
 
+if hasattr(__builtins__, 'unicode'):
+    # Inspired by: https://stackoverflow.com/questions/6432605/any-yaml-libraries-in-python-that-support-dumping-of-long-strings-as-block-liter
+    class literal_unicode(unicode):
+        pass
+else:  # PY3
+    class literal_unicode(str):
+        pass
 
-# Inspired by: https://stackoverflow.com/questions/6432605/any-yaml-libraries-in-python-that-support-dumping-of-long-strings-as-block-liter
-class literal_unicode(unicode): pass
 def literal_unicode_representer(dumper, data):
     return dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style='|')
 yaml.SafeDumper.add_representer(literal_unicode, literal_unicode_representer)


### PR DESCRIPTION
1. small change to tile_metadata so `tile build` doesn't break on python3.
2. add helm to project dependencies in setup.py