### PR TITLE
Simplify environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .venv
 .envrc
 *.pyc
+*.egg
+*.eggs
 *.egg-info/
 site/
 /.dir-locals.el
@@ -8,3 +10,6 @@ test_config_generated_output.json
 test_metadata_generated_output.yml
 .vscode/
 /ci/pipeline.yml
+tile-generator-env
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ commands. To do this, run this command in your tile-generator
 repository directory:
 
 ```
-./install-git-hooks.sh
+./install-git-hook.sh
 pip install -e .
 ```

--- a/scripts/run_local_tests.sh
+++ b/scripts/run_local_tests.sh
@@ -18,6 +18,14 @@
 
 LOCAL_TEST_DIR='temp_local_test'
 SCRIPT_DIR="$( cd "$( dirname "$0" )/.." && pwd )"
+VENV="$SCRIPT_DIR/tile-generator-env"
+deactivate >/dev/null 2>&1 || echo ''
+rm -rf $VENV
+echo "Creating a new virtual environment..."
+virtualenv -q -p python2 $VENV
+source $VENV/bin/activate
+pip install -e .
+source $VENV/bin/activate
 
 command -v tile >/dev/null 2>&1 || { echo "Command 'tile' not found." >&2; exit 1; }
 
@@ -25,6 +33,8 @@ command -v tile >/dev/null 2>&1 || { echo "Command 'tile' not found." >&2; exit 
 
 rm -rf "${SCRIPT_DIR}"/"${LOCAL_TEST_DIR}"
 mkdir "${SCRIPT_DIR}"/"${LOCAL_TEST_DIR}"
+
+"${SCRIPT_DIR}"/sample/src/build.sh
 
 if [ "$1" = "withcache" ]; then
     echo "########################################################"


### PR DESCRIPTION
- add generated files to .gitignore
- fixed typo in README
- install tile-generator from source to virtual env when running local tests
- build sample tile as part of running local tests 