### PR TITLE
Add metadata to standalone job

### DIFF
--- a/sample/tile.yml
+++ b/sample/tile.yml
@@ -472,6 +472,9 @@ packages:
     instances: 1
     dynamic_ip: 1
     type: standalone # Don't include default CF properties in generated job manifest
+    templates:
+    - name: no-op
+      release: standalone-release
 
 runtime_configs:
 - name: example-runtime-config

--- a/tile_generator/templates/tile.yml
+++ b/tile_generator/templates/tile.yml
@@ -32,17 +32,18 @@ packages:
 #   command: python app.py
 #   memory: 256M
 
-- name: my-bosh-release
-  type: bosh-release
-  path: resources/standalone-release.tgz
-  jobs:
-  - name: my-job
-    instances: 1
-    dynamic_ip: 1
-    type: standalone # Don't include default CF properties in generated job manifest
-    templates:
-    - name: my-job
-      release: standalone-release
+# New bosh release package with standalone job
+# - name: my-bosh-release
+#   type: bosh-release
+#   path: resources/standalone-release.tgz
+#   jobs:
+#   - name: my-job
+#     instances: 1
+#     dynamic_ip: 1
+#     type: standalone # Don't include default CF properties in generated job manifest
+#     templates:
+#     - name: my-job
+#       release: standalone-release
 
 # New kibosh package type only applicable for PKS
 # - name: my_pks_service

--- a/tile_generator/templates/tile.yml
+++ b/tile_generator/templates/tile.yml
@@ -40,6 +40,9 @@ packages:
     instances: 1
     dynamic_ip: 1
     type: standalone # Don't include default CF properties in generated job manifest
+    templates:
+    - name: my-job
+      release: standalone-release
 
 # New kibosh package type only applicable for PKS
 # - name: my_pks_service

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -1967,6 +1967,12 @@
           "name": "no-op", 
           "properties": {}, 
           "template": "standalone", 
+          "templates": [
+            {
+              "name": "no-op", 
+              "release": "standalone-release"
+            }
+          ], 
           "type": "standalone", 
           "varname": "no_op"
         }
@@ -3963,6 +3969,12 @@
           "name": "no-op", 
           "properties": {}, 
           "template": "standalone", 
+          "templates": [
+            {
+              "name": "no-op", 
+              "release": "standalone-release"
+            }
+          ], 
           "type": "standalone", 
           "varname": "no_op"
         }

--- a/tile_generator/test_metadata_expected_output.yml
+++ b/tile_generator/test_metadata_expected_output.yml
@@ -989,7 +989,9 @@ job_types:
   resource_label: no-op
   single_az_only: false
   static_ip: 0
-  templates: []
+  templates:
+  - name: no-op
+    release: standalone-release
 - default_internet_connected: false
   dynamic_ip: 1
   instance_definition:


### PR DESCRIPTION
The `standalone` job in the sample tile.yml is missing required metadata, causing tile deployment to fail.