### PR TITLE
#167261974 : Tile Generator delete-all errand is missing property exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ repository directory:
 ./install-git-hook.sh
 pip install -e .
 ```
+
+To avoid downloading dependencies on every `tile build`:
+1. `cd sample`
+2. `mkdir cache`
+3. `tile build --cache cache`
+
+Before executing `./scripts/run_local_tests.sh` install virtualenv with `pip install virtualenv`
+
+To execute tests using the cache, (instead of downloading artifacts again) use: 
+
+`./scripts/run_local_tests.sh withcache`
+

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ To avoid downloading dependencies on every `tile build`:
 2. `mkdir cache`
 3. `tile build --cache cache`
 
+Run indiv
+
 Before executing `./scripts/run_local_tests.sh` install virtualenv with `pip install virtualenv`
 
-To execute tests using the cache, (instead of downloading artifacts again) use: 
-
+Then to execute all test using the cache from the project root use: 
 `./scripts/run_local_tests.sh withcache`
 

--- a/ci/acceptance-tests/bosh_acceptancetest.py
+++ b/ci/acceptance-tests/bosh_acceptancetest.py
@@ -43,6 +43,20 @@ class VerifyBoshRelease(unittest.TestCase):
 	def test_all_jobs_have_manifest(self):
 		self.assertEqual(len(glob.glob('release/jobs/*/job.MF')), len(glob.glob('release/jobs/*')))
 
+	def test_form_properties_exist_in_deploy_all(self):
+		deploy_all = read_file('release/jobs/deploy-all/templates/deploy-all.sh.erb')
+		self.assertIn('export AUTHOR=', deploy_all)
+		self.assertIn('export NATS_HOST=', deploy_all)
+		self.assertIn('export NATS_HOSTS=', deploy_all)
+		self.assertIn('export NATS_PROPERTIES=', deploy_all)
+
+	def test_form_properties_exist_in_delete_all(self):
+		delete_all = read_file('release/jobs/delete-all/templates/delete-all.sh.erb')
+		self.assertIn('export AUTHOR=', delete_all)
+		self.assertIn('export NATS_HOST=', delete_all)
+		self.assertIn('export NATS_HOSTS=', delete_all)
+		self.assertIn('export NATS_PROPERTIES=', delete_all)
+
 	# def test_cf_errand_manifest_has_cf_cli_package(self):
 	# 	for manifest in glob.glob('release/jobs/*/job.MF'):
 	# 		if not manifest.startswith('release/jobs/docker-bosh-'):

--- a/ci/scripts/run-acceptancetests.sh
+++ b/ci/scripts/run-acceptancetests.sh
@@ -18,6 +18,10 @@
 
 TILE_DIR=$1
 
+# Cleanup previous run
+rm -rf ${TILE_DIR}/product
+rm -rf ${TILE_DIR}/release
+
 MY_DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_DIR="$( cd "${MY_DIR}/../.." && pwd )"
 BASE_DIR="$( cd "${REPO_DIR}/.." && pwd )"
@@ -46,6 +50,7 @@ do
 	TGZ_DIR=`echo "${TGZ_FILE}" | sed "s/\.tgz\$//"`
 	mkdir -p "${TGZ_DIR}"
 	( cd "${TGZ_DIR}"; gunzip -c "../../../${TGZ_FILE}" | tar xf - )
+	# Remove tar file so we don't get double counts in tests
 	rm "${TGZ_FILE}"
 done
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import, division, print_function
 from setuptools import setup
 import os
-import sys
 from tile_generator.version import version_string
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tile_generator/templates/jobs/delete-all.sh.erb
+++ b/tile_generator/templates/jobs/delete-all.sh.erb
@@ -31,6 +31,26 @@ function import_opsmgr_variables() {
 	export CF_SPACE={{ 'properties.space' | shell_string }}
 	export CF_TARGET=$SCHEME://api.${DOMAIN}
 	export CF_SKIP_SSL={{ 'properties.ssl.skip_cert_verify' | shell_string }}
+
+	{% for property in context.all_properties %}
+	{{ property | env_variable | indent }}``
+	{% endfor %}
+	<% empty_dict = {} %>
+	<% empty_list = [] %>
+	{% for release in context.releases.values() if release.consumes %}
+	{% for link in release.consumes %}
+	<% if_link('{{ link }}') do |link| %>
+	<% hosts = link.instances.map { |instance| instance.address } %>
+	export {{ link | shell_variable_name }}_HOST="<%= link.instances.empty? ?  "" : link.instances[0].address %>"
+	export {{ link | shell_variable_name }}_HOSTS=<%= Shellwords.escape(hosts.to_json) %>
+	export {{ link | shell_variable_name }}_PROPERTIES=<%= Shellwords.escape(link.properties.to_json) %>
+	<% end.else do %>
+	export {{ link | shell_variable_name }}_HOST=<%= Shellwords.escape(empty_list.to_json) %>
+	export {{ link | shell_variable_name }}_HOSTS=<%= Shellwords.escape(empty_list.to_json) %>
+	export {{ link | shell_variable_name }}_PROPERTIES=<%= Shellwords.escape(empty_dict.to_json) %>
+	<% end %>
+	{% endfor %}
+	{% endfor %}
 }
 
 function write_opsman_cert {


### PR DESCRIPTION
This PR addresses https://www.pivotaltracker.com/story/show/167261974 and was worked onin conjunction with @mboldt and @edwardecook 

There is some urgency to have this merged in as OverOps would like to release a tile soon and require this change.

In addition to addressing the story adding a few tests `run-acceptancetests.sh` has been made idempotent so a new tile build between runs is not longer necessary, and the readme has been updated to show hoe to use the `cache` so dependencies are not downloaded for every build.