### PR TITLE
Fix installation from source dist by including requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ recursive-include tile_generator/templates *
 include LICENSE
 include NOTICE
 include README.md
+include requirements.txt
 include version.txt


### PR DESCRIPTION
Right now, tile-generator is not installable from sdist, as `setup.py` tries to read `requirements.txt`, but that file is not included. This PR fixes the issue.