### PR TITLE
feat: add way for skipping exporting specific properties into the

### DIFF
--- a/tile_generator/templates/jobs/delete-all.sh.erb
+++ b/tile_generator/templates/jobs/delete-all.sh.erb
@@ -33,7 +33,9 @@ function import_opsmgr_variables() {
 	export CF_SKIP_SSL={{ 'properties.ssl.skip_cert_verify' | shell_string }}
 
 	{% for property in context.all_properties %}
+	{% if not property.skip_export %}
 	{{ property | env_variable | indent }}``
+	{% endif %}	
 	{% endfor %}
 	<% empty_dict = {} %>
 	<% empty_list = [] %>

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -43,7 +43,9 @@ function import_opsmgr_variables() {
 	{% endfor %}
 
 	{% for property in context.all_properties %}
+	{% if not property.skip_export %}
 	{{ property | env_variable | indent }}
+	{% endif %}
 	{% endfor %}
 	<% empty_dict = {} %>
 	<% empty_list = [] %>


### PR DESCRIPTION
environment

With lengthy environment variables the deploy-all and delete-all jobs reach a limit in the operating system when exporting values and all subsequent bash commands fail with `Argument list too long` message.

The limit when setting env variables into the app is reached before this passes, and we have successfully been able to workaround this by providing a pre-deploy hook. However environment variables are nevertheless exported inside the import_opsmgr_variables function and there is no way to override this behavior

This change allows to define a `skip_export` attribute to any property to skip exporting as environment variable both in deploy-all and delete-all job templates. If the attribute is not specified, the behavior remains as always.

The variables will still be set to the app with `cf set-env` as the function that does this does not look into the environment. and that behaviour will need to be overriden with a pre-deploy hook if needed.

