### PR TITLE
fix: requests and docker package compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click>=6.2
 Jinja2>=3.1
 PyYAML>=3.1
 docker-py>=1.6.0
-requests>2.11
+requests<2.2.29
 requests-toolbelt
 mock>=2.0.0
 pexpect>=4.2.1


### PR DESCRIPTION
When running `tile build --cache ./cache` inside the `sample` directory, I encountered the following error:

```
request() got an unexpected keyword argument 'chunked'
```

this is due to an incompatibility between the `requests` and `docker-py` packages, see https://github.com/docker/docker-py/issues/3113

After updating the constraint, the tile builds.