### PR TITLE
feat: Updated default stack to use

### DIFF
--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -220,9 +220,9 @@ function wait_till_running() {
 }
 
 function get_stack() {
-	if $CF stacks 2>&1 | grep "cflinuxfs3" > /dev/null; then
-		echo >&2 "Using cflinuxfs3 stack"
-		echo "-s cflinuxfs3"
+	if $CF stacks 2>&1 | grep "cflinuxfs4" > /dev/null; then
+		echo >&2 "Using cflinuxfs4 stack"
+		echo "-s cflinuxfs4"
 	else
 		echo >&2 "Using default stack"
 	fi


### PR DESCRIPTION
- If cflinuxfs4 is available it will be used else the default stack will be used to push apps

Authored-by: Ramkumar Vengadakrishnan <ramkumarv@vmware.com>

[#186383844] - Change default stack in tile generator