### PR TITLE
Pin cf-cli-release to version 1.63.0

### DIFF
--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -94,7 +94,7 @@ class Cf(FlagBase):
         if not 'cf-cli-release' in config_obj['releases'].keys():
             config_obj['releases']['cf-cli-release'] = {
               'name': 'cf-cli-release',
-              'path': 'https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=',
+              'path': 'https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.63.0',
             }
         if not config_obj.get('requires_product_versions'): 
             config_obj['requires_product_versions'] = list()

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -2080,7 +2080,7 @@
   "releases": {
     "cf-cli-release": {
       "name": "cf-cli-release",
-      "path": "https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v="
+      "path": "https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.63.0"
     },
     "docker-boshrelease": {
       "name": "docker-boshrelease",


### PR DESCRIPTION
This is the last CF CLI bosh release that includes cf-cli-6-linux which the tile generator relies on.

