### PR TITLE
Fix/10.2 compatibility

### DIFF
--- a/ci/acceptance-tests/bosh_acceptancetest.py
+++ b/ci/acceptance-tests/bosh_acceptancetest.py
@@ -46,16 +46,16 @@ class VerifyBoshRelease(unittest.TestCase):
 	def test_form_properties_exist_in_deploy_all(self):
 		deploy_all = read_file('release/jobs/deploy-all/templates/deploy-all.sh.erb')
 		self.assertIn(b'export AUTHOR=', deploy_all)
-		self.assertIn(b'export NATS_HOST=', deploy_all)
-		self.assertIn(b'export NATS_HOSTS=', deploy_all)
-		self.assertIn(b'export NATS_PROPERTIES=', deploy_all)
+		self.assertIn(b'export NATS_TLS_HOST=', deploy_all)
+		self.assertIn(b'export NATS_TLS_HOSTS=', deploy_all)
+		self.assertIn(b'export NATS_TLS_PROPERTIES=', deploy_all)
 
 	def test_form_properties_exist_in_delete_all(self):
 		delete_all = read_file('release/jobs/delete-all/templates/delete-all.sh.erb')
 		self.assertIn(b'export AUTHOR=', delete_all)
-		self.assertIn(b'export NATS_HOST=', delete_all)
-		self.assertIn(b'export NATS_HOSTS=', delete_all)
-		self.assertIn(b'export NATS_PROPERTIES=', delete_all)
+		self.assertIn(b'export NATS_TLS_HOST=', delete_all)
+		self.assertIn(b'export NATS_TLS_HOSTS=', delete_all)
+		self.assertIn(b'export NATS_TLS_PROPERTIES=', delete_all)
 
 	# def test_cf_errand_manifest_has_cf_cli_package(self):
 	# 	for manifest in glob.glob('release/jobs/*/job.MF'):

--- a/ci/acceptance-tests/tile_acceptancetest.py
+++ b/ci/acceptance-tests/tile_acceptancetest.py
@@ -121,10 +121,10 @@ class VerifyProperties(unittest.TestCase):
 		deploy_all_template = find_by_name(deploy_all_job['templates'], 'deploy-all')
 		self.assertIn('consumes', deploy_all_template)
 		consumes = yaml.safe_load(deploy_all_template['consumes'])
-		self.assertIn('nats', consumes)
-		self.assertIn('from', consumes['nats'])
-		self.assertEqual(consumes['nats'].get('deployment'), '(( ..cf.deployment_name ))')
-		self.assertEqual(consumes['nats'].get('from'), 'nats')
+		self.assertIn('nats-tls', consumes)
+		self.assertIn('from', consumes['nats-tls'])
+		self.assertEqual(consumes['nats-tls'].get('deployment'), '(( ..cf.deployment_name ))')
+		self.assertEqual(consumes['nats-tls'].get('from'), 'nats-tls')
 
 class VerifyConstraints(unittest.TestCase):
 
@@ -162,10 +162,10 @@ class VerifyJobs(unittest.TestCase):
 		deploy_all_sh_file = 'release/jobs/deploy-all/templates/deploy-all.sh.erb'
 		self.assertTrue(os.path.exists(deploy_all_sh_file))
 		deploy_all_sh = read_file(deploy_all_sh_file)
-		self.assertIn(b'NATS_HOST=', deploy_all_sh)
-		self.assertIn(b'NATS_HOSTS=', deploy_all_sh)
-		self.assertIn(b'cf set-env $1 NATS_HOST ', deploy_all_sh)
-		self.assertIn(b'cf set-env $1 NATS_HOSTS ', deploy_all_sh)
+		self.assertIn(b'NATS_TLS_HOST=', deploy_all_sh)
+		self.assertIn(b'NATS_TLS_HOSTS=', deploy_all_sh)
+		self.assertIn(b'cf set-env $1 NATS_TLS_HOST ', deploy_all_sh)
+		self.assertIn(b'cf set-env $1 NATS_TLS_HOSTS ', deploy_all_sh)
 
 	def test_in_deployment_link_in_deploy_all_job(self):
 		deploy_all_sh_file = 'release/jobs/deploy-all/templates/deploy-all.sh.erb'
@@ -189,9 +189,9 @@ class VerifyJobs(unittest.TestCase):
 		deploy_all_sh_file = 'release/jobs/deploy-all/templates/deploy-all.sh.erb'
 		self.assertTrue(os.path.exists(deploy_all_sh_file))
 		deploy_all_sh = read_file(deploy_all_sh_file)
-		self.assertIn(b'NATS_PROPERTIES=', deploy_all_sh)
+		self.assertIn(b'NATS_TLS_PROPERTIES=', deploy_all_sh)
 		self.assertIn(b'REDIS_PROPERTIES=', deploy_all_sh)
-		self.assertIn(b'cf set-env $1 NATS_PROPERTIES ', deploy_all_sh)
+		self.assertIn(b'cf set-env $1 NATS_TLS_PROPERTIES ', deploy_all_sh)
 		self.assertIn(b'cf set-env $1 REDIS_PROPERTIES ', deploy_all_sh)
 
 	def test_consumes_links_in_deploy_all_spec(self):
@@ -200,7 +200,7 @@ class VerifyJobs(unittest.TestCase):
 		spec = read_yaml(deploy_all_spec_file)
 		self.assertIn('consumes', spec)
 		self.assertIsNotNone(find_by_name(spec['consumes'], 'redis'))
-		self.assertIsNotNone(find_by_name(spec['consumes'], 'nats'))
+		self.assertIsNotNone(find_by_name(spec['consumes'], 'nats-tls'))
 		self.assertIsNotNone(find_by_name(spec['consumes'], 'docker-tcp'))
 
 class VerifyRuntimeConfig(unittest.TestCase):

--- a/ci/deployment-tests/app2_deploymenttest.py
+++ b/ci/deployment-tests/app2_deploymenttest.py
@@ -52,8 +52,8 @@ class VerifyApp2(unittest.TestCase):
 		env = response.json()
 		self.assertTrue(env.get('REDIS_HOST') is not None)
 		self.assertTrue(env.get('REDIS_HOSTS') is not None)
-		self.assertTrue(env.get('NATS_HOST') is not None)
-		self.assertTrue(env.get('NATS_HOSTS') is not None)
+		self.assertTrue(env.get('NATS_TLS_HOST') is not None)
+		self.assertTrue(env.get('NATS_TLS_HOSTS') is not None)
 
 	def test_receives_link_properties(self):
 		headers = { 'Accept': 'application/json' }
@@ -61,7 +61,7 @@ class VerifyApp2(unittest.TestCase):
 		response.raise_for_status()
 		env = response.json()
 		self.assertIsNotNone(json.loads(env.get('REDIS_PROPERTIES')))
-		self.assertIsNotNone(json.loads(env.get('NATS_PROPERTIES')))
+		self.assertIsNotNone(json.loads(env.get('NATS_TLS_PROPERTIES')))
 
 	def test_receives_expected_services(self):
 		headers = { 'Accept': 'application/json' }

--- a/ci/deployment-tests/app3_deploymenttest.py
+++ b/ci/deployment-tests/app3_deploymenttest.py
@@ -27,6 +27,10 @@ class VerifyApp3(unittest.TestCase):
 		self.cfinfo = opsmgr.get_cfinfo()
 		self.hostname = 'tg-test-app3.' + self.cfinfo['apps_domain']
 		self.url = 'http://' + self.hostname
+		try:
+			requests.get(self.url + '/hello', timeout=5)
+		except (requests.ConnectionError, requests.Timeout):
+			self.skipTest('App3 is not running. diego_docker feature flag is likely not enabled')
 
 	def test_responds_to_hello(self):
 		headers = { 'Accept': 'application/json' }

--- a/ci/deployment-tests/app3_deploymenttest.py
+++ b/ci/deployment-tests/app3_deploymenttest.py
@@ -27,10 +27,6 @@ class VerifyApp3(unittest.TestCase):
 		self.cfinfo = opsmgr.get_cfinfo()
 		self.hostname = 'tg-test-app3.' + self.cfinfo['apps_domain']
 		self.url = 'http://' + self.hostname
-		try:
-			requests.get(self.url + '/hello', timeout=5)
-		except (requests.ConnectionError, requests.Timeout):
-			self.skipTest('App3 is not running. diego_docker feature flag is likely not enabled')
 
 	def test_responds_to_hello(self):
 		headers = { 'Accept': 'application/json' }

--- a/ci/deployment-tests/broker2_deploymenttest.py
+++ b/ci/deployment-tests/broker2_deploymenttest.py
@@ -52,8 +52,8 @@ class VerifyApp2(unittest.TestCase):
 		env = response.json()
 		self.assertTrue(env.get('REDIS_HOST') is not None)
 		self.assertTrue(env.get('REDIS_HOSTS') is not None)
-		self.assertTrue(env.get('NATS_HOST') is not None)
-		self.assertTrue(env.get('NATS_HOSTS') is not None)
+		self.assertTrue(env.get('NATS_TLS_HOST') is not None)
+		self.assertTrue(env.get('NATS_TLS_HOSTS') is not None)
 
 	def test_receives_link_properties(self):
 		headers = { 'Accept': 'application/json' }
@@ -61,7 +61,7 @@ class VerifyApp2(unittest.TestCase):
 		response.raise_for_status()
 		env = response.json()
 		self.assertIsNotNone(json.loads(env.get('REDIS_PROPERTIES')))
-		self.assertIsNotNone(json.loads(env.get('NATS_PROPERTIES')))
+		self.assertIsNotNone(json.loads(env.get('NATS_TLS_PROPERTIES')))
 
 	def test_has_versioned_name(self):
 		headers = { 'Accept': 'application/json' }

--- a/ci/docker-tile-generator/Dockerfile
+++ b/ci/docker-tile-generator/Dockerfile
@@ -1,4 +1,4 @@
-ARG python3=mirror.gcr.io/python:3-slim
+ARG python3=mirror.gcr.io/python:3.11-slim-bookworm
 
 FROM ${python3}
 

--- a/ci/generate_pipeline_yml.py
+++ b/ci/generate_pipeline_yml.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 from jinja2 import Template
 
-clusters = ['_four', '-6_0', '_7_prerelease', '-4_0-lite', '-6_0-lite', '-10_0-lite']
+clusters = ['-10_2_0-lite', '-10_3_0-lite', '-10_3_2-lite']
 # Commenting out this as we only have one example and it breaks
 
 tiles = []  # [d for d in os.listdir('../examples') if os.path.isdir(os.path.join('../examples', d))]

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -405,9 +405,10 @@ jobs:
         path: sh
         args:
         - -c
-        - cp tile-generator-package-release/* docker-build-dir/ && cp tile-generator-dockerfile-repo/ci/docker-tile-generator/* docker-build-dir/
-        - mkdir -p image-version-tag
-        - echo "v$(cat version/version)" > image-version-tag/version
+        - |
+          cp tile-generator-package-release/* docker-build-dir/ && cp tile-generator-dockerfile-repo/ci/docker-tile-generator/* docker-build-dir/
+          mkdir -p image-version-tag
+          echo "v$(cat version/version)" > image-version-tag/version
     on_failure:
       in_parallel:
       - put: slack-alert
@@ -677,7 +678,7 @@ jobs:
           pushd ../pcf-environment*
           STEMCELL_AVAILABLE=`pcf stemcells`
           popd
-          if [[ $STEMCELL_AVAILABLE == *"stemcell-$STEMCELL_VERSION"*"$STEMCELL_OS"* ]]; then
+          if [[ $STEMCELL_AVAILABLE == *"stemcell-$STEMCELL_VERSION"*"$STEMCELL_OS"* ]] || [[ $STEMCELL_AVAILABLE == *"$STEMCELL_OS"*-"$STEMCELL_VERSION"* ]]; then
             echo "A stemcell for $STEMCELL_OS version $STEMCELL_VERSION already is in $STEMCELL_AVAILABLE skipping...";
           else
             wget https://bosh.io/stemcells/bosh-google-kvm-$STEMCELL_OS-go_agent -O bosh.io_stemcells
@@ -867,8 +868,9 @@ jobs:
           path: sh
           args:
           - -c
-          - mkdir -p image-version-tag
-          - echo "v$(cat version/version)" > image-version-tag/version
+          - |
+            mkdir -p image-version-tag
+            echo "v$(cat version/version)" > image-version-tag/version
     - file: image-version-tag/version
       load_var: image_version
     - put: tile-generator-docker-image-release

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -663,7 +663,9 @@ jobs:
         args:
         - -exc
         - |
-          apt update -y && apt install curl -y
+          apt update -y && apt install curl -y && apt install jq -y
+          pushd ./pcf-environment*
+
           curl -k -o om -L https://github.com/pivotal-cf/om/releases/download/7.20.1/om-linux-amd64-7.20.1
           chmod +x ./om
   

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -651,6 +651,35 @@ jobs:
     - get: pcf-environment{{ cluster }}
       passed: [ claim{{ cluster }} ]
       trigger: true
+  {% if '10_3' in cluster %}
+  - task: allow-root-user-in-docker-process
+    image: tile-generator-docker-image
+    config:
+      platform: linux
+      inputs:
+      - name: pcf-environment{{ cluster }}
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          apt update -y && apt install curl -y
+          curl -k -o om -L https://github.com/pivotal-cf/om/releases/download/7.20.1/om-linux-amd64-7.20.1
+          chmod +x ./om
+  
+          pcf om > om_credentials
+          source ./om_credentials
+          
+          CF_GUID=$(pcf curl \
+            /api/v0/staged/products \
+            | jq -r '.[] | select(.type == "cf") | .guid')
+            
+          ./om -k \
+            curl \
+            -x PUT \
+            -p "/api/v0/staged/products/${CF_GUID}/properties" \
+            -d '{"properties":{".properties.cloud_controller_allow_docker_root_user":{"value":true}}}'
+  {% endif %}
   - task: run-deploy-tile
     image: tile-generator-docker-image
     config:

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -189,7 +189,7 @@ resources:
 - name: python3-image
   type: registry-image
   source:
-    tag: 3.11-slim
+    tag: 3.11-slim-bookworm
     repository: ((artifactory.registry_mirror))/python
     username: ((artifactory.production_username))
     password: ((artifactory.production_password))

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -512,20 +512,17 @@ jobs:
   - put: app-docker-image
     params:
       image: docker-image-out/image.tar
-  - get: app-docker-image
-    params:
-      format: oci
   - task: populate-docker-cache
     image: tile-generator-docker-image
     config:
       platform: linux
       inputs:
-      - name: app-docker-image
+      - name: docker-image-out
       outputs:
       - name: docker-cache
       run:
         path: sh
-        args: [ "-c", 'cp app-docker-image/image.tar docker-cache/guidowb-sample-cf-app.tgz']
+        args: [ "-c", 'cp docker-image-out/image.tar docker-cache/mirror.gcr.io-guidowb-sample-cf-app.tgz']
     on_failure:
       in_parallel:
       - put: slack-alert

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -65,8 +65,8 @@ resource_types:
 - name: shepherd
   type: registry-image
   check_every: 4h
-  source:
-    repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
+  source: 
+    repository: tpe-build-harbor.tanzu.broadcom.net/shepherd/concourse-resource 
     tag: latest
 
 resources:
@@ -166,14 +166,14 @@ resources:
     version_constraint: '>=0.0.0-dev.0'
 
 - name: tile-generator-docker-image
-  type: docker-image
+  type: registry-image
   source:
     repository: tas-ecosystem-docker-prod-local.usw1.packages.broadcom.com/tanzu-isv-engineering/tile-generator-prerelease
     username: ((artifactory.production_username))
     password: ((artifactory.production_password))
 
 - name: tile-generator-docker-image-release
-  type: docker-image
+  type: registry-image
   source:
     repository: tas-ecosystem-docker-prod-local.usw1.packages.broadcom.com/tanzu-isv-engineering/tile-generator
     username: ((artifactory.production_username))
@@ -185,6 +185,7 @@ resources:
     repository: tas-ecosystem-docker-prod-local.usw1.packages.broadcom.com/partner-engineering/tile-generator-sample-app
     username: ((artifactory.production_username))
     password: ((artifactory.production_password))
+    tag: latest
 
 - name: python3-image
   type: registry-image
@@ -197,10 +198,10 @@ resources:
 {% endraw %}{% for cluster in clusters %}- name: pcf-environment{{ cluster }}
   type: shepherd
   source:
-    url: ((production_shepherd_api_endpoint))
-    service-account-key: ((production_shepherd_service_key))
+    url: ((production_lvn_shepherd.api_endpoint))
+    service-account-key: ((production_lvn_shepherd.service_key))
     lease:
-      namespace: ((production_shepherd_namespace))
+      namespace: ((production_lvn_shepherd.namespace))
       pool:
         namespace: official
         name: tas{{ cluster }}{% if not loop.last %}
@@ -244,7 +245,7 @@ jobs:
         type: registry-image
         source:
           repository: ((artifactory.registry_mirror))/python
-          tag: 3.11-slim
+          tag: 3.11-slim-bookworm
           username: ((artifactory.production_username))
           password: ((artifactory.production_password))
       platform: linux
@@ -294,7 +295,7 @@ jobs:
         type: registry-image
         source:
           repository: ((artifactory.registry_mirror))/python
-          tag: 3.11.4-slim-buster
+          tag: 3.11-slim-bookworm
           username: ((artifactory.production_username))
           password: ((artifactory.production_password))
       platform: linux
@@ -324,6 +325,7 @@ jobs:
               ./pyinstaller/build-binaries.sh
               if [ -z "$SKIP_SDIST" ]; then
                 echo "Building SDist"
+                pip install 'setuptools<69.3'
                 python setup.py sdist
                 # Setuptools normalizes versions and does not support semver.
                 # See https://github.com/pypa/setuptools/issues/308
@@ -388,7 +390,7 @@ jobs:
         type: registry-image
         source:
           repository: ((artifactory.registry_mirror))/python
-          tag: 3-slim
+          tag: 3.11-slim
           username: ((artifactory.production_username))
           password: ((artifactory.production_password))
       platform: linux

--- a/ci/pipeline.yml.jinja2
+++ b/ci/pipeline.yml.jinja2
@@ -277,7 +277,7 @@ jobs:
       pre: dev
 
 - name: package-tile-generator
-  disable_manual_trigger: true
+  disable_manual_trigger: false
   plan:
   - in_parallel:
     - get: tile-generator-repo
@@ -371,7 +371,7 @@ jobs:
           - tile-generator-dist/*
 
 - name: install-tile-generator
-  disable_manual_trigger: true
+  disable_manual_trigger: false
   plan:
   - in_parallel:
     - get: tile-generator-package
@@ -449,7 +449,7 @@ jobs:
       version: ((.:image_version))
 
 - name: build-tile
-  disable_manual_trigger: true
+  disable_manual_trigger: false
   plan:
   - in_parallel:
     - get: tile-generator-docker-image
@@ -632,7 +632,7 @@ jobs:
       timeout: 5h
 
 - name: deploy-tile{{ cluster }}
-  disable_manual_trigger: true
+  disable_manual_trigger: false
   plan:
   - in_parallel:
     - get: tile-generator-docker-image

--- a/pyinstaller/build-binaries.sh
+++ b/pyinstaller/build-binaries.sh
@@ -38,9 +38,10 @@ function create_venv {
   virtualenv -q -p python3 $VENV
   source $VENV/bin/activate
   # Build for current project. Assumes tile-generator src is up a dir
+  pip install 'setuptools<69.3'
   pip install -e $SCRIPT_DIR/../
   #https://github.com/pypa/pip/issues/6163#issuecomment-456772043
-  pip install pyinstaller --no-use-pep517
+  pip install pyinstaller==6.13.0
   pip install staticx
 }
 

--- a/sample/example-chart/values.yaml
+++ b/sample/example-chart/values.yaml
@@ -1,6 +1,6 @@
 ---
 # image source is https://github.com/cf-platform-eng/pcf-examples/tree/master/src/docker
-image: cfplatformeng/spacebears
+image: mirror.gcr.io/cfplatformeng/spacebears
 imageTag: latest
 
 spacebears:

--- a/sample/tile.yml
+++ b/sample/tile.yml
@@ -301,8 +301,8 @@ packages:
   consumes:
     redis:
       from: redis
-    nats:
-      from: nats
+    nats-tls:
+      from: nats-tls
       deployment: (( ..cf.deployment_name ))
     docker-tcp:
       from: docker
@@ -324,8 +324,8 @@ packages:
   consumes:
     redis:
       from: redis
-    nats:
-      from: nats
+    nats-tls:
+      from: nats-tls
       deployment: (( ..cf.deployment_name ))
   manifest:
     path: resources/app.zip
@@ -442,13 +442,21 @@ packages:
       # label: colocated errand X # Define the errand name to be shown.
       # description: This is an errand description.
       ###############################################################
+    - name: bpm
+      release: bpm
     - name: route_registrar
       release: routing #relies on the fact that docker-bosh adds routing
       consumes:
-        nats:
-          from: nats
+        nats-tls:
+          from: nats-tls
           deployment: (( ..cf.deployment_name ))
     properties:
+      nats:
+        fail_if_using_nats_without_tls: true
+        tls:
+          enabled: true
+          client_cert: "(( .properties.nats_client_cert.cert_pem ))"
+          client_key: "(( .properties.nats_client_cert.private_key_pem ))"
       route_registrar:
         routes:
         - name: runtime_conf_yes
@@ -460,13 +468,21 @@ packages:
     instances: 1
     dynamic_ip: 1
     templates:
+    - name: bpm
+      release: bpm
     - name: route_registrar
       release: routing
       consumes:
-        nats:
-          from: nats
+        nats-tls:
+          from: nats-tls
           deployment: (( ..cf.deployment_name ))
     properties:
+      nats:
+        fail_if_using_nats_without_tls: true
+        tls:
+          enabled: true
+          client_cert: "(( .properties.nats_client_cert.cert_pem ))"
+          client_key: "(( .properties.nats_client_cert.private_key_pem ))"
       route_registrar:
         routes:
         - name: runtime_conf_no

--- a/sample/tile.yml
+++ b/sample/tile.yml
@@ -312,7 +312,7 @@ packages:
     host: tg-test-app2-hostname       # Override hostname, default: app name
     memory: 256M                      # Override memory, default: 1G
     buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.8.0
-  health_check: none                  # Turn off health monitoring, default: true
+  health_check: process                  # Turn off health monitoring, default: true
   auto_services:                      # Auto-provision and bind services
   - name: tg-test-broker1-service     # If using a broker in the same tile, the broker must preceed the app in this file
     plan: first-plan                  # Optionally specify a plan (default is the first plan offered by the service)

--- a/sample/tile.yml
+++ b/sample/tile.yml
@@ -349,7 +349,7 @@ packages:
 
 - name: tg-test-app3
   type: docker-app
-  image: guidowb/sample-cf-app        # Start command must be specified in the Dockerfile (CMD)
+  image: mirror.gcr.io/guidowb/sample-cf-app        # Start command must be specified in the Dockerfile (CMD)
   manifest:
     memory: 256M                      # Override memory, default: 1G
   auto_services:                      # Auto-provision and bind services
@@ -360,7 +360,7 @@ packages:
 - name: tg-test-app4
   type: docker-bosh
   docker_images:
-  - guidowb/sample-cf-app
+  - mirror.gcr.io/guidowb/sample-cf-app
   cpu: 2
   memory: 512
   ephemeral_disk: 4096
@@ -372,7 +372,7 @@ packages:
   manifest: |
     containers:
     - name: app
-      image: "guidowb/sample-cf-app" # should match the docker image name
+      image: "mirror.gcr.io/guidowb/sample-cf-app" # should match the docker image name
       bind_ports:
       - '80:80'
       - '443:443'

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -145,7 +145,11 @@ class DockerBosh(FlagBase):
         }
         config_obj['releases']['routing'] = {
             'name': 'routing',
-            'path': 'https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release',
+            'path': 'https://bosh.io/d/github.com/cloudfoundry/routing-release',
+        }
+        config_obj['releases']['bpm'] = {
+            'name': 'bpm',
+            'path': 'https://bosh.io/d/github.com/cloudfoundry/bpm-release',
         }
 
         packagename = package['name']

--- a/tile_generator/package_flags.py
+++ b/tile_generator/package_flags.py
@@ -137,11 +137,11 @@ class DockerBosh(FlagBase):
             'tls_key': '(( .properties.generated_rsa_cert_credentials.private_key_pem ))',
             }
         }]
-        version = None
+        version = '1.4.26'
         version_param = '?v=' + version if version else ''
         config_obj['releases']['docker-boshrelease'] = {
             'name': 'docker-boshrelease',
-            'path': 'https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease' + version_param,
+            'path': 'https://bosh.io/d/github.com/cloudfoundry-incubator/docker-boshrelease',
         }
         config_obj['releases']['routing'] = {
             'name': 'routing',
@@ -149,7 +149,7 @@ class DockerBosh(FlagBase):
         }
         config_obj['releases']['bpm'] = {
             'name': 'bpm',
-            'path': 'https://bosh.io/d/github.com/cloudfoundry/bpm-release',
+            'path': 'https://bosh.io/d/github.com/cloudfoundry/bpm-release' + version_param,
         }
 
         packagename = package['name']

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -237,8 +237,11 @@ function deploy_app() {
 	HEALTH_CHECK="$6"
 	APP_MANIFEST="$7"
 	MANIFEST_FILE="$PACKAGE_PATH/${PKG_NAME}/manifest.yml"
-	echo "${APP_MANIFEST}" > "${MANIFEST_FILE}"
-	STACK="$(get_stack)"
+	echo "{\"applications\":[${APP_MANIFEST}]}" > "${MANIFEST_FILE}"
+	STACK=""
+	if [ -z "$DOCKER_IMAGE" ]; then
+		STACK="$(get_stack)"
+	fi
 	cf push ${APP_NAME} ${DOCKER_IMAGE} -f "${MANIFEST_FILE}" ${STACK} \
 		--no-start --no-route
 	cf map-route ${APP_NAME} ${APP_DOMAIN} --hostname ${APP_HOST}

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -414,10 +414,6 @@ add_target_org_to_admin
 {{ package.deploy | render }}
 {% else %}
 
-{% if package.is_docker_app %}
-if $CF feature-flag diego_docker 2>&1 | grep -q "enabled"; then
-{% endif %}
-
 {% if package.is_app %}
 export PKG_NAME={{ package.name }}
 export APP_NAME={{ package.name | hyphens }}-{{ context.version }}
@@ -462,13 +458,6 @@ export BUILDPACK_ORDER={{ ( 'properties.' + package.name + '.buildpack_order' ) 
 export BUILDPACK_FILE=$PACKAGE_PATH/{{ package.name }}/{{ package.path }}
 push_buildpack "$BUILDPACK_NAME" "$BUILDPACK_ORDER" "$BUILDPACK_FILE"
 {% endif %}
-
-{% if package.is_docker_app %}
-else
-echo "WARNING: Skipping docker app {{ package.name }} because Diego Docker feature flag is not enabled"
-fi
-{% endif %}
-
 
 {% endif %}
 

--- a/tile_generator/templates/jobs/deploy-all.sh.erb
+++ b/tile_generator/templates/jobs/deploy-all.sh.erb
@@ -414,6 +414,10 @@ add_target_org_to_admin
 {{ package.deploy | render }}
 {% else %}
 
+{% if package.is_docker_app %}
+if $CF feature-flag diego_docker 2>&1 | grep -q "enabled"; then
+{% endif %}
+
 {% if package.is_app %}
 export PKG_NAME={{ package.name }}
 export APP_NAME={{ package.name | hyphens }}-{{ context.version }}
@@ -458,6 +462,13 @@ export BUILDPACK_ORDER={{ ( 'properties.' + package.name + '.buildpack_order' ) 
 export BUILDPACK_FILE=$PACKAGE_PATH/{{ package.name }}/{{ package.path }}
 push_buildpack "$BUILDPACK_NAME" "$BUILDPACK_ORDER" "$BUILDPACK_FILE"
 {% endif %}
+
+{% if package.is_docker_app %}
+else
+echo "WARNING: Skipping docker app {{ package.name }} because Diego Docker feature flag is not enabled"
+fi
+{% endif %}
+
 
 {% endif %}
 

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -813,9 +813,9 @@
         "docker-tcp": {
           "from": "docker"
         },
-        "nats": {
+        "nats-tls": {
           "deployment": "(( ..cf.deployment_name ))",
-          "from": "nats"
+          "from": "nats-tls"
         },
         "redis": {
           "from": "redis"
@@ -870,9 +870,9 @@
         "path": "app.zip"
       },
       "consumes": {
-        "nats": {
+        "nats-tls": {
           "deployment": "(( ..cf.deployment_name ))",
-          "from": "nats"
+          "from": "nats-tls"
         },
         "redis": {
           "from": "redis"
@@ -1490,6 +1490,14 @@
               "identity": "(( .properties.my_creds.identity ))",
               "password": "(( .properties.my_creds.password ))"
             },
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
+            },
             "opsman_ca": "(( $ops_manager.ca_certificate ))",
             "org": "(( .properties.org.value ))",
             "password": "(( .properties.password.value ))",
@@ -1628,6 +1636,14 @@
           },
           "name": "node-yes",
           "properties": {
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
+            },
             "route_registrar": {
               "routes": [
                 {
@@ -1654,10 +1670,14 @@
               "run_default": true
             },
             {
+              "name": "bpm",
+              "release": "bpm"
+            },
+            {
               "consumes": {
-                "nats": {
+                "nats-tls": {
                   "deployment": "(( ..cf.deployment_name ))",
-                  "from": "nats"
+                  "from": "nats-tls"
                 }
               },
               "name": "route_registrar",
@@ -1708,6 +1728,14 @@
             "my_creds": {
               "identity": "(( .properties.my_creds.identity ))",
               "password": "(( .properties.my_creds.password ))"
+            },
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
             },
             "opsman_ca": "(( $ops_manager.ca_certificate ))",
             "org": "(( .properties.org.value ))",
@@ -1847,6 +1875,14 @@
           },
           "name": "node-no",
           "properties": {
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
+            },
             "route_registrar": {
               "routes": [
                 {
@@ -1863,10 +1899,14 @@
           "template": "node-no",
           "templates": [
             {
+              "name": "bpm",
+              "release": "bpm"
+            },
+            {
               "consumes": {
-                "nats": {
+                "nats-tls": {
                   "deployment": "(( ..cf.deployment_name ))",
-                  "from": "nats"
+                  "from": "nats-tls"
                 }
               },
               "name": "route_registrar",
@@ -2078,6 +2118,10 @@
   ],
   "purge_service_brokers": true,
   "releases": {
+    "bpm": {
+      "name": "bpm",
+      "path": "https://bosh.io/d/github.com/cloudfoundry/bpm-release"
+    },
     "cf-cli-release": {
       "name": "cf-cli-release",
       "path": "https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=2.6.0"
@@ -2088,7 +2132,7 @@
     },
     "routing": {
       "name": "routing",
-      "path": "https://bosh.io/d/github.com/cloudfoundry-incubator/cf-routing-release"
+      "path": "https://bosh.io/d/github.com/cloudfoundry/routing-release"
     },
     "runtime_test_release": {
       "is_bosh_release": true,
@@ -2106,9 +2150,9 @@
         "docker-tcp": {
           "from": "docker"
         },
-        "nats": {
+        "nats-tls": {
           "deployment": "(( ..cf.deployment_name ))",
-          "from": "nats"
+          "from": "nats-tls"
         },
         "redis": {
           "from": "redis"
@@ -2118,9 +2162,9 @@
         "docker-tcp": {
           "from": "docker"
         },
-        "nats": {
+        "nats-tls": {
           "deployment": "(( ..cf.deployment_name ))",
-          "from": "nats"
+          "from": "nats-tls"
         },
         "redis": {
           "from": "redis"
@@ -2884,9 +2928,9 @@
             "docker-tcp": {
               "from": "docker"
             },
-            "nats": {
+            "nats-tls": {
               "deployment": "(( ..cf.deployment_name ))",
-              "from": "nats"
+              "from": "nats-tls"
             },
             "redis": {
               "from": "redis"
@@ -2941,9 +2985,9 @@
             "path": "app.zip"
           },
           "consumes": {
-            "nats": {
+            "nats-tls": {
               "deployment": "(( ..cf.deployment_name ))",
-              "from": "nats"
+              "from": "nats-tls"
             },
             "redis": {
               "from": "redis"
@@ -3563,6 +3607,14 @@
               "identity": "(( .properties.my_creds.identity ))",
               "password": "(( .properties.my_creds.password ))"
             },
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
+            },
             "opsman_ca": "(( $ops_manager.ca_certificate ))",
             "org": "(( .properties.org.value ))",
             "password": "(( .properties.password.value ))",
@@ -3701,6 +3753,14 @@
           },
           "name": "node-yes",
           "properties": {
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
+            },
             "route_registrar": {
               "routes": [
                 {
@@ -3727,10 +3787,14 @@
               "run_default": true
             },
             {
+              "name": "bpm",
+              "release": "bpm"
+            },
+            {
               "consumes": {
-                "nats": {
+                "nats-tls": {
                   "deployment": "(( ..cf.deployment_name ))",
-                  "from": "nats"
+                  "from": "nats-tls"
                 }
               },
               "name": "route_registrar",
@@ -3781,6 +3845,14 @@
             "my_creds": {
               "identity": "(( .properties.my_creds.identity ))",
               "password": "(( .properties.my_creds.password ))"
+            },
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
             },
             "opsman_ca": "(( $ops_manager.ca_certificate ))",
             "org": "(( .properties.org.value ))",
@@ -3920,6 +3992,14 @@
           },
           "name": "node-no",
           "properties": {
+            "nats": {
+              "fail_if_using_nats_without_tls": true,
+              "tls": {
+                "client_cert": "(( .properties.nats_client_cert.cert_pem ))",
+                "client_key": "(( .properties.nats_client_cert.private_key_pem ))",
+                "enabled": true
+              }
+            },
             "route_registrar": {
               "routes": [
                 {
@@ -3936,10 +4016,14 @@
           "template": "node-no",
           "templates": [
             {
+              "name": "bpm",
+              "release": "bpm"
+            },
+            {
               "consumes": {
-                "nats": {
+                "nats-tls": {
                   "deployment": "(( ..cf.deployment_name ))",
-                  "from": "nats"
+                  "from": "nats-tls"
                 }
               },
               "name": "route_registrar",
@@ -4169,7 +4253,7 @@
         "releases": [
           {
             "name": "runtime-test-release",
-            "version": "0.1.5"
+            "version": "0.2.0"
           }
         ]
       }

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -2120,7 +2120,7 @@
   "releases": {
     "bpm": {
       "name": "bpm",
-      "path": "https://bosh.io/d/github.com/cloudfoundry/bpm-release"
+      "path": "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.26"
     },
     "cf-cli-release": {
       "name": "cf-cli-release",

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -827,7 +827,7 @@
           "path": "resources/app.zip"
         }
       ],
-      "health_check": "none",
+      "health_check": "process",
       "is_app": true,
       "is_cf": true,
       "manifest": {
@@ -2942,7 +2942,7 @@
               "path": "resources/app.zip"
             }
           ],
-          "health_check": "none",
+          "health_check": "process",
           "is_app": true,
           "is_cf": true,
           "manifest": {

--- a/tile_generator/test_config_expected_output.json
+++ b/tile_generator/test_config_expected_output.json
@@ -965,7 +965,7 @@
         }
       ],
       "files": [],
-      "image": "guidowb/sample-cf-app",
+      "image": "mirror.gcr.io/guidowb/sample-cf-app",
       "is_app": true,
       "is_cf": true,
       "is_docker": true,
@@ -994,13 +994,13 @@
     {
       "cpu": 2,
       "docker_images": [
-        "guidowb/sample-cf-app"
+        "mirror.gcr.io/guidowb/sample-cf-app"
       ],
       "ephemeral_disk": 4096,
       "files": [
         {
-          "name": "guidowb-sample-cf-app.tgz",
-          "path": "docker:guidowb/sample-cf-app"
+          "name": "mirror.gcr.io-guidowb-sample-cf-app.tgz",
+          "path": "docker:mirror.gcr.io/guidowb/sample-cf-app"
         }
       ],
       "instances": 1,
@@ -1017,7 +1017,7 @@
             "env_file": [
               "/var/vcap/jobs/docker-bosh-tg_test_app4/bin/opsmgr.env"
             ],
-            "image": "guidowb/sample-cf-app",
+            "image": "mirror.gcr.io/guidowb/sample-cf-app",
             "name": "app",
             "volumes": [
               "/var/vcap/data/certs:/mnt/certs/opsman-certs:ro",
@@ -2697,13 +2697,13 @@
           "package": {
             "cpu": 2,
             "docker_images": [
-              "guidowb/sample-cf-app"
+              "mirror.gcr.io/guidowb/sample-cf-app"
             ],
             "ephemeral_disk": 4096,
             "files": [
               {
-                "name": "guidowb-sample-cf-app.tgz",
-                "path": "docker:guidowb/sample-cf-app"
+                "name": "mirror.gcr.io-guidowb-sample-cf-app.tgz",
+                "path": "docker:mirror.gcr.io/guidowb/sample-cf-app"
               }
             ],
             "instances": 1,
@@ -2720,7 +2720,7 @@
                   "env_file": [
                     "/var/vcap/jobs/docker-bosh-tg_test_app4/bin/opsmgr.env"
                   ],
-                  "image": "guidowb/sample-cf-app",
+                  "image": "mirror.gcr.io/guidowb/sample-cf-app",
                   "name": "app",
                   "volumes": [
                     "/var/vcap/data/certs:/mnt/certs/opsman-certs:ro",
@@ -3080,7 +3080,7 @@
             }
           ],
           "files": [],
-          "image": "guidowb/sample-cf-app",
+          "image": "mirror.gcr.io/guidowb/sample-cf-app",
           "is_app": true,
           "is_cf": true,
           "is_docker": true,
@@ -3109,13 +3109,13 @@
         {
           "cpu": 2,
           "docker_images": [
-            "guidowb/sample-cf-app"
+            "mirror.gcr.io/guidowb/sample-cf-app"
           ],
           "ephemeral_disk": 4096,
           "files": [
             {
-              "name": "guidowb-sample-cf-app.tgz",
-              "path": "docker:guidowb/sample-cf-app"
+              "name": "mirror.gcr.io-guidowb-sample-cf-app.tgz",
+              "path": "docker:mirror.gcr.io/guidowb/sample-cf-app"
             }
           ],
           "instances": 1,
@@ -3132,7 +3132,7 @@
                 "env_file": [
                   "/var/vcap/jobs/docker-bosh-tg_test_app4/bin/opsmgr.env"
                 ],
-                "image": "guidowb/sample-cf-app",
+                "image": "mirror.gcr.io/guidowb/sample-cf-app",
                 "name": "app",
                 "volumes": [
                   "/var/vcap/data/certs:/mnt/certs/opsman-certs:ro",

--- a/tile_generator/test_metadata_expected_output.yml
+++ b/tile_generator/test_metadata_expected_output.yml
@@ -543,7 +543,7 @@ job_types:
       - 8443:8443
       env_file:
       - /var/vcap/jobs/docker-bosh-tg_test_app4/bin/opsmgr.env
-      image: guidowb/sample-cf-app
+      image: mirror.gcr.io/guidowb/sample-cf-app
       name: app
       volumes:
       - /var/vcap/data/certs:/mnt/certs/opsman-certs:ro

--- a/tile_generator/test_metadata_expected_output.yml
+++ b/tile_generator/test_metadata_expected_output.yml
@@ -44,6 +44,13 @@ property_blueprints:
   name: generated_rsa_cert_credentials
   optional: false
   type: rsa_cert_credentials
+- configurable: false
+  default:
+    domains:
+    - nats.service.cf.internal
+  name: nats_client_cert
+  optional: false
+  type: rsa_cert_credentials
 - configurable: true
   name: custom_dynamic_service_plan_1
   optional: true
@@ -556,6 +563,12 @@ job_types:
     my_creds:
       identity: (( .properties.my_creds.identity ))
       password: (( .properties.my_creds.password ))
+    nats:
+      fail_if_using_nats_without_tls: true
+      tls:
+        client_cert: (( .properties.nats_client_cert.cert_pem ))
+        client_key: (( .properties.nats_client_cert.private_key_pem ))
+        enabled: true
     opsman_ca: (( $ops_manager.ca_certificate ))
     org: (( .properties.org.value ))
     password: (( .properties.password.value ))
@@ -657,15 +670,17 @@ job_types:
   single_az_only: false
   static_ip: 1
   templates:
-  - name: containers
-    release: docker
   - name: docker
     release: docker
   - name: docker-bosh-tg_test_app4
     release: test-tile
+  - name: containers
+    release: docker
+  - name: bpm
+    release: bpm
   - consumes: |
-      nats:
-        from: nats
+      nats-tls:
+        from: nats-tls
         deployment: (( ..cf.deployment_name ))
     name: route_registrar
     release: routing
@@ -838,9 +853,9 @@ job_types:
   - consumes: |
       docker-tcp:
         from: docker
-      nats:
+      nats-tls:
         deployment: (( ..cf.deployment_name ))
-        from: nats
+        from: nats-tls
       redis:
         from: redis
     name: deploy-all
@@ -1009,9 +1024,9 @@ job_types:
   - consumes: |
       docker-tcp:
         from: docker
-      nats:
+      nats-tls:
         deployment: (( ..cf.deployment_name ))
-        from: nats
+        from: nats-tls
       redis:
         from: redis
     name: delete-all
@@ -1386,6 +1401,12 @@ job_types:
     my_creds:
       identity: (( .properties.my_creds.identity ))
       password: (( .properties.my_creds.password ))
+    nats:
+      fail_if_using_nats_without_tls: true
+      tls:
+        client_cert: (( .properties.nats_client_cert.cert_pem ))
+        client_key: (( .properties.nats_client_cert.private_key_pem ))
+        enabled: true
     opsman_ca: (( $ops_manager.ca_certificate ))
     org: (( .properties.org.value ))
     password: (( .properties.password.value ))
@@ -1523,10 +1544,12 @@ job_types:
   templates:
   - name: no-op
     release: no-op-release
+  - name: bpm
+    release: bpm
   - consumes: |
-      nats:
+      nats-tls:
         deployment: (( ..cf.deployment_name ))
-        from: nats
+        from: nats-tls
     name: route_registrar
     release: routing
 - dynamic_ip: 1
@@ -1563,6 +1586,12 @@ job_types:
     my_creds:
       identity: (( .properties.my_creds.identity ))
       password: (( .properties.my_creds.password ))
+    nats:
+      fail_if_using_nats_without_tls: true
+      tls:
+        client_cert: (( .properties.nats_client_cert.cert_pem ))
+        client_key: (( .properties.nats_client_cert.private_key_pem ))
+        enabled: true
     opsman_ca: (( $ops_manager.ca_certificate ))
     org: (( .properties.org.value ))
     password: (( .properties.password.value ))
@@ -1698,10 +1727,12 @@ job_types:
   single_az_only: false
   static_ip: 0
   templates:
+  - name: bpm
+    release: bpm
   - consumes: |
-      nats:
+      nats-tls:
         deployment: (( ..cf.deployment_name ))
-        from: nats
+        from: nats-tls
     name: route_registrar
     release: routing
 - dynamic_ip: 1

--- a/tile_generator/tile_metadata.py
+++ b/tile_generator/tile_metadata.py
@@ -95,6 +95,13 @@ class TileMetadata(object):
                 'optional': False,
                 'type': 'rsa_cert_credentials'
             })
+            self.tile_metadata['property_blueprints'].append({
+                'configurable': False,
+                'default': {'domains': ['nats.service.cf.internal']},
+                'name': 'nats_client_cert',
+                'optional': False,
+                'type': 'rsa_cert_credentials'
+            })
 
         for service_plan_form in self.config['service_plan_forms']:
             #
@@ -442,13 +449,14 @@ class TileMetadata(object):
                     'single_az_only': False,
                     'static_ip': 1,
                     'templates': [
-                        {'name': 'containers', 'release': 'docker'},
                         {'name': 'docker', 'release': 'docker'},
                         {'name': job.get('type'), 'release': release.get('name')},
-                        {'consumes': 
+                        {'name': 'containers', 'release': 'docker'},
+                        {'name': 'bpm', 'release': 'bpm'},
+                        {'consumes':
                             literal_unicode(
-                                'nats:\n'
-                                '  from: nats\n'
+                                'nats-tls:\n'
+                                '  from: nats-tls\n'
                                 '  deployment: (( ..cf.deployment_name ))\n'
                             ),
                             'name': 'route_registrar',
@@ -474,6 +482,14 @@ class TileMetadata(object):
                         'uris': ['%s.(( ..cf.cloud_controller.system_domain.value ))' % route_name]
                     })
                 release_job_manifest['route_registrar'] = routes
+                release_job_manifest['nats'] = {
+                    'fail_if_using_nats_without_tls': True,
+                    'tls': {
+                        'client_cert': '(( .properties.nats_client_cert.cert_pem ))',
+                        'client_key': '(( .properties.nats_client_cert.private_key_pem ))',
+                        'enabled': True,
+                    },
+                }
 
                 for prop in self.config.get('all_properties'):
                     if 'job' not in prop:


### PR DESCRIPTION
Passes on tas lite 10.2 environment. 

- upgrades routing releases, which requires bpm (adds it) and sets up nats-tls + mtls 
- fixes cf cli 8 usages
- skip docker_app based cf pushes tests in ci in foundations that do not support it (will revert before merging)

